### PR TITLE
Add ZeroMQ-based message broker plugin

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -93,13 +93,6 @@ jobs:
         python-version: ['3.9']
         database-backend: [sqlite]
 
-    services:
-      rabbitmq:
-        image: rabbitmq:3.8.14-management
-        ports:
-        - 5672:5672
-        - 15672:15672
-
     steps:
     - uses: actions/checkout@v4
 
@@ -120,7 +113,7 @@ jobs:
     - name: Run test suite
       env:
         AIIDA_WARN_v3: 0
-      run: pytest --disable-warnings -n auto --db-backend ${{ matrix.database-backend }} -m 'not nightly' tests/
+      run: pytest --disable-warnings -n auto --db-backend ${{ matrix.database-backend }} --broker-backend zmq -m 'not nightly' tests/
 
 
   tests-presto:
@@ -145,7 +138,7 @@ jobs:
     - name: Run test suite
       env:
         AIIDA_WARN_v3: 0
-      run: pytest -n auto -m 'presto' tests/
+      run: pytest -n auto --broker-backend zmq -m 'presto' tests/
 
 
   verdi:

--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.13']
         database-backend: [psql]
+        broker-backend: [rmq, zmq]
 
     services:
       postgres:
@@ -72,7 +73,7 @@ jobs:
         AIIDA_TEST_PROFILE: test_aiida
         AIIDA_WARN_v3: 1
       run: |
-        pytest -n auto --db-backend ${{ matrix.database-backend }} -m 'not nightly' tests/ ${{ matrix.python-version == '3.13' && '--cov aiida' || '' }}
+        pytest -n auto --db-backend ${{ matrix.database-backend }} --broker-backend ${{ matrix.broker-backend }} -m 'not nightly' tests/ ${{ matrix.python-version == '3.13' && '--cov aiida' || '' }}
 
     - name: Upload coverage report
       if: matrix.python-version == 3.13 && github.repository == 'aiidateam/aiida-core'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
-    services:
-      rabbitmq:
-        image: rabbitmq:3.8.14-management
-        ports:
-        - 5672:5672
-        - 15672:15672
-
     steps:
     - uses: actions/checkout@v4
 
@@ -77,7 +70,7 @@ jobs:
       uses: ./.github/actions/install-aiida-core
 
     - name: Run sub-set of test suite
-      run: pytest -s -m requires_rmq --db-backend=sqlite tests/
+      run: pytest -s -m requires_broker --broker-backend zmq --db-backend=sqlite tests/
 
   publish-pypi:
     if: startsWith(github.ref, 'refs/tags/')

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -346,9 +346,8 @@ Below is a list with all available subcommands.
 
       By default the command creates a profile that uses SQLite for the database. It
       automatically checks for RabbitMQ running on the localhost, and, if it can connect,
-      configures that as the broker for the profile. Otherwise, the profile is created without
-      a broker, in which case some functionality will be unavailable, most notably running the
-      daemon and submitting processes to said daemon.
+      configures that as the broker for the profile. Otherwise, it falls back to the ZMQ
+      broker which requires no external services and is started automatically with the daemon.
 
       When the `--use-postgres` flag is toggled, the command tries to connect to the
       PostgreSQL server with connection paramaters taken from the `--postgres-hostname`,

--- a/docs/source/reference/command_line.rst
+++ b/docs/source/reference/command_line.rst
@@ -32,6 +32,31 @@ Below is a list with all available subcommands.
       version  Print the current version of an archive's schema.
 
 
+.. _reference:command-line:verdi-broker:
+
+``verdi broker``
+----------------
+
+.. code:: console
+
+    Usage:  [OPTIONS] COMMAND [ARGS]...
+
+      Manage the message broker service.
+
+      The message broker is required for daemon operation and process control. RabbitMQ is an
+      external service managed by your system's service manager. ZMQ is a built-in broker
+      service that is managed by these commands.
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      restart  Restart the broker service.
+      start    Start the broker service.
+      status   Show the broker service status.
+      stop     Stop the broker service.
+
+
 .. _reference:command-line:verdi-calcjob:
 
 ``verdi calcjob``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -432,7 +432,7 @@ markers = [
   'requires_rmq: requires RabbitMQ specifically (not compatible with ZMQ broker)',
   'requires_broker: requires a message broker (RabbitMQ or ZMQ)',
   'requires_psql: requires a connection to PostgreSQL DB',
-  'presto: automatic marker meaning "not requires_broker and not requires_psql"',
+  'presto: automatic marker for tests needing no external services (not requires_rmq, not requires_psql)',
   'sphinx: set parameters for the sphinx `app` fixture'
 ]
 minversion = '7.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -429,9 +429,10 @@ filterwarnings = [
 ]
 markers = [
   'nightly: long running tests that should rarely be affected and so only run nightly',
-  'requires_rmq: requires a connection (on port 5672) to RabbitMQ',
+  'requires_rmq: requires RabbitMQ specifically (not compatible with ZMQ broker)',
+  'requires_broker: requires a message broker (RabbitMQ or ZMQ)',
   'requires_psql: requires a connection to PostgreSQL DB',
-  'presto: automatic marker meaning "not requires_rmq and not requires_psql"',
+  'presto: automatic marker meaning "not requires_broker and not requires_psql"',
   'sphinx: set parameters for the sphinx `app` fixture'
 ]
 minversion = '7.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ requires-python = '>=3.9'
 
 [project.entry-points.'aiida.brokers']
 'core.rabbitmq' = 'aiida.brokers.rabbitmq.broker:RabbitmqBroker'
+'core.zmq' = 'aiida.brokers.zmq.broker:ZmqBroker'
 
 [project.entry-points.'aiida.calculations']
 'core.arithmetic.add' = 'aiida.calculations.arithmetic.add:ArithmeticAddCalculation'

--- a/src/aiida/brokers/utils.py
+++ b/src/aiida/brokers/utils.py
@@ -1,0 +1,43 @@
+"""Shared utilities for message brokers."""
+
+from __future__ import annotations
+
+import uuid
+from functools import partial
+
+import yaml
+
+__all__ = ('YAML_DECODER', 'YAML_ENCODER', 'AiidaYamlLoader')
+
+
+class AiidaYamlLoader(yaml.FullLoader):
+    """Custom YAML loader that can deserialize Python UUIDs.
+
+    Extends FullLoader to handle the !!python/object:uuid.UUID tag that
+    yaml.dump produces when serializing UUID objects. This is needed because
+    FullLoader (for security reasons) cannot deserialize arbitrary Python objects.
+
+    This loader only adds support for UUIDs, which are commonly used as process
+    identifiers in AiiDA and plumpy.
+    """
+
+    pass
+
+
+def _uuid_constructor(loader: yaml.Loader, node: yaml.MappingNode) -> uuid.UUID:
+    """Construct a UUID from the YAML python/object representation.
+
+    :param loader: The YAML loader instance
+    :param node: The YAML node containing the UUID data
+    :return: The reconstructed UUID object
+    """
+    mapping = loader.construct_mapping(node)
+    return uuid.UUID(int=mapping['int'])
+
+
+# Register the UUID constructor
+AiidaYamlLoader.add_constructor('tag:yaml.org,2002:python/object:uuid.UUID', _uuid_constructor)
+
+# Default encoder and decoder for broker messages
+YAML_ENCODER = yaml.dump
+YAML_DECODER = partial(yaml.load, Loader=AiidaYamlLoader)

--- a/src/aiida/brokers/zmq/__init__.py
+++ b/src/aiida/brokers/zmq/__init__.py
@@ -1,0 +1,15 @@
+"""ZeroMQ-based message broker for AiiDA."""
+
+from .broker import ZmqBroker
+from .communicator import ZmqCommunicator
+from .controller import ZmqBrokerController
+from .server import ZmqBrokerServer
+from .service import ZmqBrokerService
+
+__all__ = [
+    'ZmqBroker',
+    'ZmqBrokerController',
+    'ZmqBrokerServer',
+    'ZmqBrokerService',
+    'ZmqCommunicator',
+]

--- a/src/aiida/brokers/zmq/__init__.py
+++ b/src/aiida/brokers/zmq/__init__.py
@@ -3,13 +3,16 @@
 from .broker import ZmqBroker
 from .communicator import ZmqCommunicator
 from .controller import ZmqBrokerController
+from .defaults import BROKER_DEFAULTS, get_zmq_config
 from .server import ZmqBrokerServer
 from .service import ZmqBrokerService
 
 __all__ = [
+    'BROKER_DEFAULTS',
     'ZmqBroker',
     'ZmqBrokerController',
     'ZmqBrokerServer',
     'ZmqBrokerService',
     'ZmqCommunicator',
+    'get_zmq_config',
 ]

--- a/src/aiida/brokers/zmq/__init__.py
+++ b/src/aiida/brokers/zmq/__init__.py
@@ -2,7 +2,7 @@
 
 from .broker import ZmqBroker
 from .communicator import ZmqCommunicator
-from .controller import ZmqBrokerController
+from .client import ZmqBrokerManagementClient
 from .defaults import BROKER_DEFAULTS, get_zmq_config
 from .server import ZmqBrokerServer
 from .service import ZmqBrokerService
@@ -10,7 +10,7 @@ from .service import ZmqBrokerService
 __all__ = [
     'BROKER_DEFAULTS',
     'ZmqBroker',
-    'ZmqBrokerController',
+    'ZmqBrokerManagementClient',
     'ZmqBrokerServer',
     'ZmqBrokerService',
     'ZmqCommunicator',

--- a/src/aiida/brokers/zmq/broker.py
+++ b/src/aiida/brokers/zmq/broker.py
@@ -1,0 +1,166 @@
+"""ZMQ Broker - AiiDA Broker wrapper for ZMQ communicator."""
+
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+from aiida.brokers.broker import Broker
+from aiida.common.log import AIIDA_LOGGER
+
+from .communicator import ZmqCommunicator
+from .controller import ZmqBrokerController
+from .queue import PersistentQueue
+
+if t.TYPE_CHECKING:
+    from aiida.manage.configuration.profile import Profile
+
+__all__ = ('ZmqBroker',)
+
+LOGGER = AIIDA_LOGGER.getChild('broker.zmq')
+
+
+class ZmqBroker(Broker):
+    """AiiDA Broker implementation using ZeroMQ.
+
+    This broker connects to a ZmqBrokerService to handle messaging.
+    The broker service must be started separately.
+
+    Configuration paths (derived from profile):
+    - storage_path: {config_dir}/broker/{profile_uuid}/storage/
+    - sockets_path: {temp_dir}/ (created by broker service, path stored in broker.sockets file)
+    - router_endpoint: ipc://{sockets_path}/router.sock
+    - pub_endpoint: ipc://{sockets_path}/pub.sock
+
+    Note: Socket files are stored in a temporary directory to avoid Unix domain
+    socket path length limits (~107 bytes).
+    """
+
+    # Class attribute for type discovery
+    Communicator = ZmqCommunicator
+
+    def __init__(self, profile: 'Profile') -> None:
+        """Construct a new ZMQ broker instance.
+
+        :param profile: The AiiDA profile
+        """
+        super().__init__(profile)
+
+        self._communicator: ZmqCommunicator | None = None
+
+        # Derive paths from profile
+        from aiida.manage.configuration import get_config_path
+
+        config_dir = Path(get_config_path()).parent
+        broker_dir = config_dir / 'broker' / profile.uuid
+
+        # Storage path is in the AiiDA config directory
+        self._storage_path = broker_dir / 'storage'
+        self._broker_dir = broker_dir
+
+        # Controller for managing the broker service
+        self._controller = ZmqBrokerController(broker_dir)
+
+        LOGGER.debug('ZMQ Broker initialized for profile: %s', profile.name)
+        LOGGER.debug('Broker directory: %s', broker_dir)
+        LOGGER.debug('Storage path: %s', self._storage_path)
+
+    def __str__(self) -> str:
+        """Return string representation with broker status."""
+        if self._controller.is_running():
+            status = self._controller.get_status()
+            pid = status.get('pid', '?') if status else '?'
+            return f'ZMQ Broker (PID {pid}) @ {self._broker_dir}'
+        return f'ZMQ Broker @ {self._broker_dir} <not running>'
+
+    @property
+    def storage_path(self) -> Path:
+        """Return the path for task queue storage."""
+        return self._storage_path
+
+    @property
+    def router_endpoint(self) -> str | None:
+        """Return the ROUTER socket endpoint.
+
+        :return: Endpoint string, or None if broker is not running
+        """
+        return self._controller.router_endpoint
+
+    @property
+    def pub_endpoint(self) -> str | None:
+        """Return the PUB socket endpoint.
+
+        :return: Endpoint string, or None if broker is not running
+        """
+        return self._controller.pub_endpoint
+
+    @property
+    def controller(self) -> ZmqBrokerController:
+        """Return the broker controller for managing the broker service."""
+        return self._controller
+
+    def get_communicator(self) -> ZmqCommunicator:
+        """Return a ZMQ communicator instance.
+
+        Creates and starts the communicator if not already created.
+
+        :return: The ZMQ communicator
+        :raises ConnectionError: If broker service is not running
+        """
+        if self._communicator is None:
+            router_endpoint = self.router_endpoint
+            pub_endpoint = self.pub_endpoint
+
+            if router_endpoint is None or pub_endpoint is None:
+                raise ConnectionError(f'{self}')
+
+            self._communicator = ZmqCommunicator(
+                router_endpoint=router_endpoint,
+                pub_endpoint=pub_endpoint,
+            )
+            self._communicator.start()
+            LOGGER.info('ZMQ Communicator started')
+
+        return self._communicator
+
+    def iterate_tasks(self) -> t.Iterator[dict]:
+        """Iterate over pending tasks in the queue.
+
+        This provides direct access to the task queue for inspection.
+
+        :yield: Task data dictionaries
+        """
+        queue_path = self._storage_path / 'tasks'
+        if not queue_path.exists():
+            return
+
+        queue = PersistentQueue(queue_path)
+        for task_id, task_data in queue.get_all_pending():
+            yield task_data
+
+    def close(self) -> None:
+        """Close the broker and release resources."""
+        if self._communicator is not None:
+            self._communicator.close()
+            self._communicator = None
+            LOGGER.info('ZMQ Broker closed')
+
+    def __enter__(self) -> 'ZmqBroker':
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Context manager exit."""
+        self.close()
+
+
+def get_broker_base_path(profile: 'Profile') -> Path:
+    """Get the base path for broker data for a profile.
+
+    :param profile: The AiiDA profile
+    :return: Base path for broker data
+    """
+    from aiida.manage.configuration import get_config_path
+
+    config_dir = Path(get_config_path()).parent
+    return config_dir / 'broker' / profile.uuid

--- a/src/aiida/brokers/zmq/broker.py
+++ b/src/aiida/brokers/zmq/broker.py
@@ -10,7 +10,7 @@ from aiida.brokers.broker import Broker
 from aiida.common.log import AIIDA_LOGGER
 
 from .communicator import ZmqCommunicator
-from .controller import ZmqBrokerController
+from .client import ZmqBrokerManagementClient
 from .queue import PersistentQueue
 
 if t.TYPE_CHECKING:
@@ -59,8 +59,8 @@ class ZmqBroker(Broker):
         self._storage_path = broker_dir / 'storage'
         self._broker_dir = broker_dir
 
-        # Controller for managing the broker service
-        self._controller = ZmqBrokerController(broker_dir)
+        # Management client for broker service lifecycle (start/stop/status)
+        self._management_client = ZmqBrokerManagementClient(broker_dir)
 
         LOGGER.debug('ZMQ Broker initialized for profile: %s', profile.name)
         LOGGER.debug('Broker directory: %s', broker_dir)
@@ -68,8 +68,8 @@ class ZmqBroker(Broker):
 
     def __str__(self) -> str:
         """Return string representation with broker status."""
-        if self._controller.is_running():
-            status = self._controller.get_status()
+        if self._management_client.is_running():
+            status = self._management_client.get_status()
             pid = status.get('pid', '?') if status else '?'
             return f'ZMQ Broker (PID {pid}) @ {self._broker_dir}'
         return f'ZMQ Broker @ {self._broker_dir} <not running>'
@@ -85,7 +85,7 @@ class ZmqBroker(Broker):
 
         :return: Endpoint string, or None if broker is not running
         """
-        return self._controller.router_endpoint
+        return self._management_client.router_endpoint
 
     @property
     def pub_endpoint(self) -> str | None:
@@ -93,12 +93,12 @@ class ZmqBroker(Broker):
 
         :return: Endpoint string, or None if broker is not running
         """
-        return self._controller.pub_endpoint
+        return self._management_client.pub_endpoint
 
     @property
-    def controller(self) -> ZmqBrokerController:
-        """Return the broker controller for managing the broker service."""
-        return self._controller
+    def management_client(self) -> ZmqBrokerManagementClient:
+        """Return the management client for broker service lifecycle."""
+        return self._management_client
 
     def get_communicator(self) -> ZmqCommunicator:
         """Return a ZMQ communicator instance.

--- a/src/aiida/brokers/zmq/client.py
+++ b/src/aiida/brokers/zmq/client.py
@@ -165,12 +165,19 @@ class ZmqBrokerManagementClient:
         except (json.JSONDecodeError, OSError):
             return None
 
-    def start(self, foreground: bool = False, wait: bool = True, timeout: float = 10.0) -> bool:
+    def start(
+        self,
+        foreground: bool = False,
+        wait: bool = True,
+        timeout: float = 10.0,
+        task_timeout: float = 10.0,
+    ) -> bool:
         """Start the broker service.
 
         :param foreground: If True, run in foreground (blocking); else daemonize
         :param wait: If True and not foreground, wait for service to start
         :param timeout: Timeout in seconds when waiting for service to start
+        :param task_timeout: Seconds before an unacked task is requeued (default: 10)
         :return: True if service started successfully
         """
         if self.is_running():
@@ -186,6 +193,8 @@ class ZmqBrokerManagementClient:
             'aiida.brokers.zmq.service',
             '--base-path',
             str(self._base_path),
+            '--task-timeout',
+            str(task_timeout),
         ]
 
         if foreground:

--- a/src/aiida/brokers/zmq/client.py
+++ b/src/aiida/brokers/zmq/client.py
@@ -1,7 +1,7 @@
-"""ZMQ Broker Controller - client-side control for ZmqBrokerService.
+"""ZMQ Broker Management Client - lifecycle management for ZmqBrokerService.
 
-This module provides a client-side interface to interact with the broker service
-by reading PID/status files. Similar to AiiDA's DaemonClient pattern.
+This module provides a management interface to start/stop the broker service
+and query its status via PID/status files. Analogous to RabbitmqManagementClient.
 """
 
 from __future__ import annotations
@@ -23,8 +23,8 @@ except ImportError:
     HAS_PSUTIL = False
 
 
-class ZmqBrokerController:
-    """Controller for ZmqBrokerService.
+class ZmqBrokerManagementClient:
+    """Management client for ZmqBrokerService.
 
     Allows external code to:
     - Start/stop the broker service
@@ -32,6 +32,7 @@ class ZmqBrokerController:
     - Get service status
 
     Interacts with the service via PID/status files, not direct IPC.
+    Analogous to RabbitmqManagementClient for the RabbitMQ broker.
     """
 
     def __init__(self, base_path: Path | str):

--- a/src/aiida/brokers/zmq/client.py
+++ b/src/aiida/brokers/zmq/client.py
@@ -170,14 +170,12 @@ class ZmqBrokerManagementClient:
         foreground: bool = False,
         wait: bool = True,
         timeout: float = 10.0,
-        task_timeout: float = 10.0,
     ) -> bool:
         """Start the broker service.
 
         :param foreground: If True, run in foreground (blocking); else daemonize
         :param wait: If True and not foreground, wait for service to start
         :param timeout: Timeout in seconds when waiting for service to start
-        :param task_timeout: Seconds before an unacked task is requeued (default: 10)
         :return: True if service started successfully
         """
         if self.is_running():
@@ -193,8 +191,6 @@ class ZmqBrokerManagementClient:
             'aiida.brokers.zmq.service',
             '--base-path',
             str(self._base_path),
-            '--task-timeout',
-            str(task_timeout),
         ]
 
         if foreground:

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -489,10 +489,11 @@ class ZmqCommunicator:
             try:
                 result = subscriber(self, body)
 
-                # Resolve Future before serializing: plumpy subscribers
+                # Resolve Future(s) before serializing: plumpy subscribers
                 # return a kiwipy.Future (concurrent.futures.Future) whose
-                # result is computed on the runner's event loop thread.
-                if isinstance(result, Future):
+                # result may itself be another Future (via plum_to_kiwi_future
+                # chaining), so we loop until we get a concrete value.
+                while isinstance(result, Future):
                     result = result.result(timeout=RPC_TIMEOUT)
 
                 # Send response

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import threading
 import uuid
@@ -10,6 +9,8 @@ from concurrent.futures import Future
 from typing import Any, Callable
 
 import zmq
+
+from aiida.brokers.utils import YAML_DECODER, YAML_ENCODER
 
 from .protocol import (
     MessageType,
@@ -42,8 +43,8 @@ class ZmqCommunicator:
         self,
         router_endpoint: str,
         pub_endpoint: str,
-        encoder: Callable[[Any], str] = json.dumps,
-        decoder: Callable[[str], Any] = json.loads,
+        encoder: Callable[[Any], str] | None = None,
+        decoder: Callable[[str], Any] | None = None,
         client_id: str | None = None,
     ):
         """Initialize the communicator.
@@ -56,8 +57,8 @@ class ZmqCommunicator:
         """
         self._router_endpoint = router_endpoint
         self._pub_endpoint = pub_endpoint
-        self._encoder = encoder
-        self._decoder = decoder
+        self._encoder = encoder if encoder is not None else YAML_ENCODER
+        self._decoder = decoder if decoder is not None else YAML_DECODER
         self._client_id = client_id or f'client-{uuid.uuid4().hex[:8]}'
 
         # ZMQ sockets

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -1,0 +1,535 @@
+"""ZeroMQ Communicator - client implementing kiwipy Communicator interface."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import uuid
+from concurrent.futures import Future
+from typing import Any, Callable
+
+import zmq
+
+from .protocol import (
+    MessageType,
+    decode_message,
+    encode_message,
+    make_broadcast_message,
+    make_rpc_message,
+    make_rpc_response,
+    make_subscribe_message,
+    make_task_ack,
+    make_task_message,
+    make_task_nack,
+    make_task_response,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ZmqCommunicator:
+    """ZMQ client implementing kiwipy Communicator interface.
+
+    Connects to a ZmqBrokerService to send/receive messages.
+
+    Socket architecture:
+        DEALER - Connects to broker ROUTER for request-reply
+        SUB    - Connects to broker PUB for broadcasts
+    """
+
+    def __init__(
+        self,
+        router_endpoint: str,
+        pub_endpoint: str,
+        encoder: Callable[[Any], str] = json.dumps,
+        decoder: Callable[[str], Any] = json.loads,
+        client_id: str | None = None,
+    ):
+        """Initialize the communicator.
+
+        :param router_endpoint: ZMQ endpoint for ROUTER socket (broker)
+        :param pub_endpoint: ZMQ endpoint for PUB socket (broker)
+        :param encoder: Function to encode messages
+        :param decoder: Function to decode messages
+        :param client_id: Optional client identifier
+        """
+        self._router_endpoint = router_endpoint
+        self._pub_endpoint = pub_endpoint
+        self._encoder = encoder
+        self._decoder = decoder
+        self._client_id = client_id or f'client-{uuid.uuid4().hex[:8]}'
+
+        # ZMQ sockets
+        self._context: zmq.Context | None = None
+        self._dealer: zmq.Socket | None = None
+        self._sub: zmq.Socket | None = None
+        self._poller: zmq.Poller | None = None
+
+        # Pending futures for responses
+        self._pending_futures: dict[str, Future] = {}
+        self._futures_lock = threading.Lock()
+
+        # Subscribers
+        self._task_subscribers: dict[str, Callable] = {}
+        self._rpc_subscribers: dict[str, Callable] = {}
+        self._broadcast_subscribers: dict[str, Callable] = {}
+
+        # State
+        self._closed = True
+        self._poll_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    @property
+    def client_id(self) -> str:
+        """Return the client identifier."""
+        return self._client_id
+
+    def is_closed(self) -> bool:
+        """Check if communicator is closed."""
+        return self._closed
+
+    def start(self) -> None:
+        """Start the communicator.
+
+        Connects to broker and starts background polling thread.
+        """
+        if not self._closed:
+            return
+
+        _LOGGER.info('Starting ZMQ Communicator: %s', self._client_id)
+
+        # Create ZMQ context
+        self._context = zmq.Context()
+
+        # DEALER socket for request-reply with broker
+        self._dealer = self._context.socket(zmq.DEALER)
+        self._dealer.setsockopt_string(zmq.IDENTITY, self._client_id)
+        self._dealer.connect(self._router_endpoint)
+
+        # SUB socket for broadcasts
+        self._sub = self._context.socket(zmq.SUB)
+        self._sub.connect(self._pub_endpoint)
+        self._sub.setsockopt_string(zmq.SUBSCRIBE, '')  # Subscribe to all
+
+        # Set up poller
+        self._poller = zmq.Poller()
+        self._poller.register(self._dealer, zmq.POLLIN)
+        self._poller.register(self._sub, zmq.POLLIN)
+
+        self._closed = False
+        self._stop_event.clear()
+
+        # Start background polling thread
+        self._poll_thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._poll_thread.start()
+
+        _LOGGER.info('ZMQ Communicator started')
+
+    def close(self) -> None:
+        """Close the communicator.
+
+        Stops polling thread and closes sockets.
+        """
+        if self._closed:
+            return
+
+        _LOGGER.info('Closing ZMQ Communicator: %s', self._client_id)
+
+        self._closed = True
+        self._stop_event.set()
+
+        # Wait for poll thread to stop
+        if self._poll_thread and self._poll_thread.is_alive():
+            self._poll_thread.join(timeout=2.0)
+
+        # Clean up sockets
+        if self._poller:
+            if self._dealer:
+                self._poller.unregister(self._dealer)
+            if self._sub:
+                self._poller.unregister(self._sub)
+            self._poller = None
+
+        if self._dealer:
+            self._dealer.close()
+            self._dealer = None
+
+        if self._sub:
+            self._sub.close()
+            self._sub = None
+
+        if self._context:
+            self._context.term()
+            self._context = None
+
+        # Cancel pending futures
+        with self._futures_lock:
+            for future in self._pending_futures.values():
+                if not future.done():
+                    future.cancel()
+            self._pending_futures.clear()
+
+        _LOGGER.info('ZMQ Communicator closed')
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    # === Task operations (kiwipy interface) ===
+
+    def task_send(self, task: Any, no_reply: bool = False) -> Future | None:
+        """Send a task to the broker for processing.
+
+        :param task: Task payload
+        :param no_reply: If True, don't wait for response
+        :return: Future for the task result, or None if no_reply=True
+        """
+        self._ensure_open()
+
+        msg = make_task_message(task, self._client_id, no_reply)
+        task_id = msg['id']
+
+        future: Future[Any] | None = None
+        if not no_reply:
+            future = Future()
+            with self._futures_lock:
+                self._pending_futures[task_id] = future
+
+        self._send(msg)
+        _LOGGER.debug('Sent task: %s', task_id)
+
+        return future
+
+    def add_task_subscriber(self, subscriber: Callable, identifier: str | None = None) -> str:
+        """Register as a task subscriber.
+
+        :param subscriber: Callback function(communicator, task) -> result
+        :param identifier: Optional subscriber identifier
+        :return: The subscriber identifier
+        """
+        self._ensure_open()
+
+        identifier = identifier or f'task-{uuid.uuid4().hex[:8]}'
+        self._task_subscribers[identifier] = subscriber
+
+        # Register with broker
+        msg = make_subscribe_message(MessageType.SUBSCRIBE_TASK, self._client_id, identifier)
+        self._send(msg)
+
+        _LOGGER.info('Added task subscriber: %s', identifier)
+        return identifier
+
+    def remove_task_subscriber(self, identifier: str) -> None:
+        """Remove a task subscriber.
+
+        :param identifier: Subscriber identifier
+        """
+        if identifier in self._task_subscribers:
+            del self._task_subscribers[identifier]
+
+            if not self._closed:
+                msg = make_subscribe_message(MessageType.UNSUBSCRIBE_TASK, self._client_id, identifier)
+                self._send(msg)
+
+            _LOGGER.info('Removed task subscriber: %s', identifier)
+
+    # === RPC operations (kiwipy interface) ===
+
+    def rpc_send(self, recipient_id: str, msg: Any) -> Future:
+        """Send an RPC message to a specific recipient.
+
+        :param recipient_id: Target recipient identifier
+        :param msg: Message payload
+        :return: Future for the RPC result
+        """
+        self._ensure_open()
+
+        rpc_msg = make_rpc_message(recipient_id, msg, self._client_id)
+        rpc_id = rpc_msg['id']
+
+        future: Future[Any] = Future()
+        with self._futures_lock:
+            self._pending_futures[rpc_id] = future
+
+        self._send(rpc_msg)
+        _LOGGER.debug('Sent RPC to %s: %s', recipient_id, rpc_id)
+
+        return future
+
+    def add_rpc_subscriber(self, subscriber: Callable, identifier: str | None = None) -> str:
+        """Register as an RPC subscriber.
+
+        :param subscriber: Callback function(communicator, msg) -> result
+        :param identifier: Optional subscriber identifier
+        :return: The subscriber identifier
+        """
+        self._ensure_open()
+
+        identifier = identifier or f'rpc-{uuid.uuid4().hex[:8]}'
+        self._rpc_subscribers[identifier] = subscriber
+
+        # Register with broker
+        msg = make_subscribe_message(MessageType.SUBSCRIBE_RPC, self._client_id, identifier)
+        self._send(msg)
+
+        _LOGGER.info('Added RPC subscriber: %s', identifier)
+        return identifier
+
+    def remove_rpc_subscriber(self, identifier: str) -> None:
+        """Remove an RPC subscriber.
+
+        :param identifier: Subscriber identifier
+        """
+        if identifier in self._rpc_subscribers:
+            del self._rpc_subscribers[identifier]
+
+            if not self._closed:
+                msg = make_subscribe_message(MessageType.UNSUBSCRIBE_RPC, self._client_id, identifier)
+                self._send(msg)
+
+            _LOGGER.info('Removed RPC subscriber: %s', identifier)
+
+    # === Broadcast operations (kiwipy interface) ===
+
+    def broadcast_send(
+        self,
+        body: Any,
+        sender: str | None = None,
+        subject: str | None = None,
+        correlation_id: str | None = None,
+    ) -> bool:
+        """Send a broadcast message.
+
+        :param body: Message body
+        :param sender: Optional sender identifier
+        :param subject: Optional message subject
+        :param correlation_id: Optional correlation ID
+        :return: True if sent successfully
+        """
+        self._ensure_open()
+
+        msg = make_broadcast_message(
+            body,
+            sender or self._client_id,
+            subject,
+            correlation_id,
+        )
+        self._send(msg)
+        _LOGGER.debug('Sent broadcast: %s', subject)
+        return True
+
+    def add_broadcast_subscriber(
+        self,
+        subscriber: Callable,
+        identifier: str | None = None,
+    ) -> str:
+        """Register as a broadcast subscriber.
+
+        :param subscriber: Callback function(communicator, body, sender, subject, correlation_id)
+        :param identifier: Optional subscriber identifier
+        :return: The subscriber identifier
+        """
+        identifier = identifier or f'broadcast-{uuid.uuid4().hex[:8]}'
+        self._broadcast_subscribers[identifier] = subscriber
+        _LOGGER.info('Added broadcast subscriber: %s', identifier)
+        return identifier
+
+    def remove_broadcast_subscriber(self, identifier: str) -> None:
+        """Remove a broadcast subscriber.
+
+        :param identifier: Subscriber identifier
+        """
+        if identifier in self._broadcast_subscribers:
+            del self._broadcast_subscribers[identifier]
+            _LOGGER.info('Removed broadcast subscriber: %s', identifier)
+
+    # === Internal methods ===
+
+    def _ensure_open(self) -> None:
+        """Ensure communicator is open."""
+        if self._closed:
+            raise RuntimeError('Communicator is closed')
+
+    def _send(self, msg: dict) -> None:
+        """Send a message to the broker."""
+        if not self._dealer:
+            raise RuntimeError('Communicator not connected')
+
+        encoded = encode_message(msg, self._encoder)
+        self._dealer.send_multipart([b'', encoded])
+
+    def _poll_loop(self) -> None:
+        """Background thread polling for messages."""
+        _LOGGER.debug('Poll loop started')
+
+        while not self._stop_event.is_set() and not self._closed:
+            try:
+                if not self._poller:
+                    break
+
+                socks = dict(self._poller.poll(100))  # 100ms timeout
+
+                if self._dealer in socks:
+                    self._handle_dealer_message()
+
+                if self._sub in socks:
+                    self._handle_sub_message()
+
+            except zmq.ZMQError as exc:
+                if not self._closed:
+                    _LOGGER.error('ZMQ error in poll loop: %s', exc)
+                break
+            except Exception as exc:
+                _LOGGER.exception('Error in poll loop: %s', exc)
+
+        _LOGGER.debug('Poll loop stopped')
+
+    def _handle_dealer_message(self) -> None:
+        """Handle message from DEALER socket."""
+        if not self._dealer:
+            return
+
+        frames = self._dealer.recv_multipart()
+        # Skip empty delimiter
+        msg_frame = frames[1] if len(frames) > 1 and frames[0] == b'' else frames[0]
+
+        msg = decode_message(msg_frame, self._decoder)
+        msg_type = msg.get('type')
+
+        _LOGGER.debug('Received from broker: %s', msg_type)
+
+        if msg_type == MessageType.TASK.value:
+            self._handle_task(msg)
+        elif msg_type == MessageType.TASK_RESPONSE.value:
+            self._handle_task_response(msg)
+        elif msg_type == MessageType.RPC.value:
+            self._handle_rpc(msg)
+        elif msg_type == MessageType.RPC_RESPONSE.value:
+            self._handle_rpc_response(msg)
+        else:
+            _LOGGER.warning('Unknown message type from broker: %s', msg_type)
+
+    def _handle_sub_message(self) -> None:
+        """Handle message from SUB socket (broadcasts)."""
+        if not self._sub:
+            return
+
+        data = self._sub.recv()
+        msg = decode_message(data, self._decoder)
+
+        if msg.get('type') == MessageType.BROADCAST.value:
+            self._handle_broadcast(msg)
+
+    def _handle_task(self, msg: dict) -> None:
+        """Handle incoming task from broker."""
+        task_id = msg['id']
+        body = msg.get('body')
+        no_reply = msg.get('no_reply', False)
+
+        _LOGGER.debug('Handling task: %s', task_id)
+
+        # Find a subscriber to handle the task
+        for identifier, subscriber in self._task_subscribers.items():
+            try:
+                result = subscriber(self, body)
+
+                # Send acknowledgment
+                ack_msg = make_task_ack(task_id, self._client_id)
+                self._send(ack_msg)
+
+                # Send response if expected
+                if not no_reply:
+                    response = make_task_response(task_id, self._client_id, result=result)
+                    self._send(response)
+
+                _LOGGER.debug('Task completed: %s', task_id)
+                return
+
+            except Exception as exc:
+                _LOGGER.exception('Task subscriber %s failed: %s', identifier, exc)
+                # Try next subscriber
+
+        # No subscriber handled the task, nack it
+        _LOGGER.warning('No subscriber handled task: %s', task_id)
+        nack_msg = make_task_nack(task_id, self._client_id)
+        self._send(nack_msg)
+
+    def _handle_task_response(self, msg: dict) -> None:
+        """Handle task response from broker."""
+        task_id = msg.get('task_id')
+        if not task_id:
+            return
+
+        with self._futures_lock:
+            future = self._pending_futures.pop(task_id, None)
+
+        if future and not future.done():
+            error = msg.get('error')
+            if error:
+                future.set_exception(Exception(error))
+            else:
+                future.set_result(msg.get('result'))
+
+    def _handle_rpc(self, msg: dict) -> None:
+        """Handle incoming RPC from broker."""
+        rpc_id = msg['id']
+        body = msg.get('body')
+
+        _LOGGER.debug('Handling RPC: %s', rpc_id)
+
+        # Find a subscriber to handle the RPC
+        for identifier, subscriber in self._rpc_subscribers.items():
+            try:
+                result = subscriber(self, body)
+
+                # Send response
+                response = make_rpc_response(rpc_id, self._client_id, result=result)
+                self._send(response)
+
+                _LOGGER.debug('RPC completed: %s', rpc_id)
+                return
+
+            except Exception as exc:
+                _LOGGER.exception('RPC subscriber %s failed: %s', identifier, exc)
+                response = make_rpc_response(rpc_id, self._client_id, error=str(exc))
+                self._send(response)
+                return
+
+        # No subscriber handled the RPC
+        _LOGGER.warning('No subscriber handled RPC: %s', rpc_id)
+        response = make_rpc_response(rpc_id, self._client_id, error='No handler registered')
+        self._send(response)
+
+    def _handle_rpc_response(self, msg: dict) -> None:
+        """Handle RPC response from broker."""
+        rpc_id = msg.get('rpc_id')
+        if not rpc_id:
+            return
+
+        with self._futures_lock:
+            future = self._pending_futures.pop(rpc_id, None)
+
+        if future and not future.done():
+            error = msg.get('error')
+            if error:
+                future.set_exception(Exception(error))
+            else:
+                future.set_result(msg.get('result'))
+
+    def _handle_broadcast(self, msg: dict) -> None:
+        """Handle broadcast message."""
+        body = msg.get('body')
+        sender = msg.get('sender')
+        subject = msg.get('subject')
+        correlation_id = msg.get('correlation_id')
+
+        for identifier, subscriber in self._broadcast_subscribers.items():
+            try:
+                subscriber(self, body, sender, subject, correlation_id)
+            except Exception as exc:
+                _LOGGER.exception('Broadcast subscriber %s failed: %s', identifier, exc)

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -138,6 +138,26 @@ class ZmqCommunicator:
 
         _LOGGER.info('Closing ZMQ Communicator: %s', self._client_id)
 
+        # Unsubscribe all subscribers before closing so the broker server
+        # removes our identity from its routing tables.  Without this, the
+        # broker may dispatch tasks/RPCs to our dead identity, silently
+        # dropping the messages.
+        for identifier in list(self._task_subscribers):
+            try:
+                msg = make_subscribe_message(MessageType.UNSUBSCRIBE_TASK, self._client_id, identifier)
+                self._send(msg)
+            except Exception:
+                pass
+        self._task_subscribers.clear()
+
+        for identifier in list(self._rpc_subscribers):
+            try:
+                msg = make_subscribe_message(MessageType.UNSUBSCRIBE_RPC, self._client_id, identifier)
+                self._send(msg)
+            except Exception:
+                pass
+        self._rpc_subscribers.clear()
+
         self._closed = True
         self._stop_event.set()
 

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -77,6 +77,10 @@ class ZmqCommunicator:
         self._rpc_subscribers: dict[str, Callable] = {}
         self._broadcast_subscribers: dict[str, Callable] = {}
 
+        # Tasks in progress: task_id -> (Future, no_reply).  We delay the
+        # ACK until the Future resolves so the broker can redeliver if we die.
+        self._in_progress_tasks: dict[str, tuple[Future, bool]] = {}
+
         # State
         self._closed = True
         self._poll_thread: threading.Thread | None = None
@@ -402,6 +406,10 @@ class ZmqCommunicator:
                 if self._sub in socks:
                     self._handle_sub_message()
 
+                # Finalize completed in-progress tasks (send ACK + result)
+                if self._in_progress_tasks:
+                    self._process_in_progress_tasks()
+
             except zmq.ZMQError as exc:
                 if not self._closed:
                     _LOGGER.error('ZMQ error in poll loop: %s', exc)
@@ -433,6 +441,8 @@ class ZmqCommunicator:
             self._handle_rpc(msg)
         elif msg_type == MessageType.RPC_RESPONSE.value:
             self._handle_rpc_response(msg)
+        elif msg_type == MessageType.PING.value:
+            pass  # Liveness probe from broker — no action needed
         else:
             _LOGGER.warning('Unknown message type from broker: %s', msg_type)
 
@@ -460,16 +470,19 @@ class ZmqCommunicator:
             try:
                 result = subscriber(self, body)
 
-                # Send acknowledgment
-                ack_msg = make_task_ack(task_id, self._client_id)
-                self._send(ack_msg)
-
-                # Send response if expected
-                if not no_reply:
-                    response = make_task_response(task_id, self._client_id, result=result)
-                    self._send(response)
-
-                _LOGGER.debug('Task completed: %s', task_id)
+                if isinstance(result, Future):
+                    # Long-running task (e.g. continue_process).  Delay the
+                    # ACK so the broker can redeliver if we die.
+                    self._in_progress_tasks[task_id] = (result, no_reply)
+                    _LOGGER.debug('Task in progress (deferred ACK): %s', task_id)
+                else:
+                    # Immediate result — ACK right away
+                    ack_msg = make_task_ack(task_id, self._client_id)
+                    self._send(ack_msg)
+                    if not no_reply:
+                        response = make_task_response(task_id, self._client_id, result=result)
+                        self._send(response)
+                    _LOGGER.debug('Task completed: %s', task_id)
                 return
 
             except Exception as exc:
@@ -480,6 +493,58 @@ class ZmqCommunicator:
         _LOGGER.warning('No subscriber handled task: %s', task_id)
         nack_msg = make_task_nack(task_id, self._client_id)
         self._send(nack_msg)
+
+    def _process_in_progress_tasks(self) -> None:
+        """Check in-progress tasks and ACK completed ones."""
+        completed = []
+
+        for task_id, (future, no_reply) in self._in_progress_tasks.items():
+            if future.done():
+                if future.cancelled():
+                    # Task was cancelled (e.g., during shutdown).  Don't ACK —
+                    # the broker will detect our disconnect and requeue.
+                    _LOGGER.debug('Cancelled in-progress task dropped: %s', task_id)
+                    completed.append(task_id)
+                    continue
+                # Task finished — send ACK (and result if needed)
+                try:
+                    ack_msg = make_task_ack(task_id, self._client_id)
+                    self._send(ack_msg)
+                    if not no_reply:
+                        self._send_task_result(task_id, future)
+                    _LOGGER.debug('Deferred task completed, ACK sent: %s', task_id)
+                except Exception:
+                    _LOGGER.exception('Failed to finalise task %s', task_id)
+                completed.append(task_id)
+
+        for task_id in completed:
+            del self._in_progress_tasks[task_id]
+
+    def _send_task_result(self, task_id: str, result: Any) -> None:
+        """Send a task response, resolving Futures if needed.
+
+        For tasks whose result is a Future (e.g. ``continue_process``), we
+        cannot serialize the Future directly.  Instead we attach a callback
+        so the response is sent once the Future resolves.
+        """
+        if isinstance(result, Future):
+            def _on_done(fut: Future) -> None:
+                try:
+                    resolved = fut.result()
+                    # The resolved value may itself be a Future (chained)
+                    self._send_task_result(task_id, resolved)
+                except Exception as exc:
+                    _LOGGER.exception('Task %s future failed: %s', task_id, exc)
+                    try:
+                        response = make_task_response(task_id, self._client_id, error=str(exc))
+                        self._send(response)
+                    except Exception:
+                        pass
+
+            result.add_done_callback(_on_done)
+        else:
+            response = make_task_response(task_id, self._client_id, result=result)
+            self._send(response)
 
     def _handle_task_response(self, msg: dict) -> None:
         """Handle task response from broker."""

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -80,6 +80,11 @@ class ZmqCommunicator:
         # ACK until the Future resolves so the broker can redeliver if we die.
         self._in_progress_tasks: dict[str, tuple[Future, bool]] = {}
 
+        # RPCs in progress: rpc_id -> (recipient, Future).  We poll these
+        # in the poll loop so the response is sent from the poll thread
+        # (ZMQ sockets are not thread-safe).
+        self._in_progress_rpcs: dict[str, tuple[str, Future]] = {}
+
         # State
         self._closed = True
         self._poll_thread: threading.Thread | None = None
@@ -411,6 +416,10 @@ class ZmqCommunicator:
                 if self._in_progress_tasks:
                     self._process_in_progress_tasks()
 
+                # Finalize completed in-progress RPCs (send response)
+                if self._in_progress_rpcs:
+                    self._process_in_progress_rpcs()
+
             except zmq.ZMQError as exc:
                 if not self._closed:
                     _LOGGER.error('ZMQ error in poll loop: %s', exc)
@@ -521,31 +530,36 @@ class ZmqCommunicator:
         for task_id in completed:
             del self._in_progress_tasks[task_id]
 
-    def _send_rpc_result(self, rpc_id: str, result: Any) -> None:
-        """Send an RPC response, resolving Futures if needed.
+    def _process_in_progress_rpcs(self) -> None:
+        """Check in-progress RPCs and send responses for completed ones.
 
-        For RPCs whose result is a Future (e.g. plumpy's ``_schedule_rpc``),
-        we cannot serialize the Future directly.  Instead we attach a callback
-        so the response is sent once the Future resolves.
+        This runs on the poll thread so all DEALER sends are single-threaded.
         """
-        if isinstance(result, Future):
-            def _on_done(fut: Future) -> None:
-                try:
-                    resolved = fut.result()
-                    # The resolved value may itself be a Future (chained)
-                    self._send_rpc_result(rpc_id, resolved)
-                except Exception as exc:
-                    _LOGGER.exception('RPC %s future failed: %s', rpc_id, exc)
-                    try:
-                        response = make_rpc_response(rpc_id, self._client_id, error=str(exc))
-                        self._send(response)
-                    except Exception:
-                        pass
+        completed = []
 
-            result.add_done_callback(_on_done)
-        else:
-            response = make_rpc_response(rpc_id, self._client_id, result=result)
-            self._send(response)
+        for rpc_id, (recipient, future) in self._in_progress_rpcs.items():
+            if future.done():
+                if future.cancelled():
+                    completed.append(rpc_id)
+                    continue
+                try:
+                    result = future.result()
+                    # Unwrap nested done Futures (chained results)
+                    while isinstance(result, Future) and result.done():
+                        result = result.result()
+                    if isinstance(result, Future):
+                        # Still pending — swap in the inner Future and keep waiting
+                        self._in_progress_rpcs[rpc_id] = (recipient, result)
+                        continue
+                    response = make_rpc_response(rpc_id, self._client_id, result=result)
+                    self._send(response)
+                except Exception as exc:
+                    response = make_rpc_response(rpc_id, self._client_id, error=str(exc))
+                    self._send(response)
+                completed.append(rpc_id)
+
+        for rpc_id in completed:
+            del self._in_progress_rpcs[rpc_id]
 
     def _send_task_result(self, task_id: str, result: Any) -> None:
         """Send a task response, resolving Futures if needed.
@@ -619,7 +633,12 @@ class ZmqCommunicator:
 
         try:
             result = subscriber(self, body)
-            self._send_rpc_result(rpc_id, result)
+            if isinstance(result, Future):
+                self._in_progress_rpcs[rpc_id] = (recipient, result)
+                _LOGGER.debug('RPC in progress (deferred response): %s', rpc_id)
+                return
+            response = make_rpc_response(rpc_id, self._client_id, result=result)
+            self._send(response)
             _LOGGER.debug('RPC handled: %s', rpc_id)
 
         except Exception as exc:

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -495,7 +495,15 @@ class ZmqCommunicator:
             if error:
                 future.set_exception(Exception(error))
             else:
-                future.set_result(msg.get('result'))
+                # Wrap the result in a resolved kiwipy.Future.  Callers
+                # (e.g. revive_processes) expect task results to be Futures
+                # with a .done()/.result() interface, matching kiwipy/RMQ
+                # behaviour where the result is a Future chain.
+                import kiwipy
+
+                result_future = kiwipy.Future()
+                result_future.set_result(msg.get('result'))
+                future.set_result(result_future)
 
     def _handle_rpc(self, msg: dict) -> None:
         """Handle incoming RPC from broker."""

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -490,9 +490,11 @@ class ZmqCommunicator:
                 result = subscriber(self, body)
 
                 # Resolve Future(s) before serializing: plumpy subscribers
-                # return a kiwipy.Future (concurrent.futures.Future) whose
-                # result may itself be another Future (via plum_to_kiwi_future
-                # chaining), so we loop until we get a concrete value.
+                # (via convert_to_comm) return a kiwipy.Future whose result
+                # may itself be another Future (via plum_to_kiwi_future
+                # chaining). We resolve all layers to get a concrete value.
+                # Callers use unwrap_kiwi_future to handle both nested and
+                # flat responses, so fully resolving here is correct.
                 while isinstance(result, Future):
                     result = result.result(timeout=RPC_TIMEOUT)
 

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -501,40 +501,44 @@ class ZmqCommunicator:
         """Handle incoming RPC from broker."""
         rpc_id = msg['id']
         body = msg.get('body')
+        recipient = str(msg['recipient']) if 'recipient' in msg else None
 
-        _LOGGER.debug('Handling RPC: %s', rpc_id)
+        _LOGGER.debug('Handling RPC: %s (recipient=%s)', rpc_id, recipient)
 
-        # Find a subscriber to handle the RPC
-        for identifier, subscriber in self._rpc_subscribers.items():
-            try:
-                result = subscriber(self, body)
+        # Route to the specific subscriber for this recipient.  The broker
+        # already performed coarse-grained routing (by client identity), but
+        # a single communicator may serve many processes, so we must dispatch
+        # to the right one by matching the recipient identifier.
+        subscriber = self._rpc_subscribers.get(recipient) if recipient else None
 
-                # Resolve Future(s) before serializing: plumpy subscribers
-                # (via convert_to_comm) return a kiwipy.Future whose result
-                # may itself be another Future (via plum_to_kiwi_future
-                # chaining). We resolve all layers to get a concrete value.
-                # Callers use unwrap_kiwi_future to handle both nested and
-                # flat responses, so fully resolving here is correct.
-                while isinstance(result, Future):
-                    result = result.result(timeout=RPC_TIMEOUT)
+        if subscriber is None:
+            _LOGGER.warning('No subscriber for RPC recipient %s: %s', recipient, rpc_id)
+            response = make_rpc_response(rpc_id, self._client_id, error=f'No handler for {recipient}')
+            self._send(response)
+            return
 
-                # Send response
-                response = make_rpc_response(rpc_id, self._client_id, result=result)
-                self._send(response)
+        try:
+            result = subscriber(self, body)
 
-                _LOGGER.debug('RPC completed: %s', rpc_id)
-                return
+            # Resolve Future(s) before serializing: plumpy subscribers
+            # (via convert_to_comm) return a kiwipy.Future whose result
+            # may itself be another Future (via plum_to_kiwi_future
+            # chaining). We resolve all layers to get a concrete value.
+            # Callers use unwrap_kiwi_future to handle both nested and
+            # flat responses, so fully resolving here is correct.
+            while isinstance(result, Future):
+                result = result.result(timeout=RPC_TIMEOUT)
 
-            except Exception as exc:
-                _LOGGER.exception('RPC subscriber %s failed: %s', identifier, exc)
-                response = make_rpc_response(rpc_id, self._client_id, error=str(exc))
-                self._send(response)
-                return
+            # Send response
+            response = make_rpc_response(rpc_id, self._client_id, result=result)
+            self._send(response)
 
-        # No subscriber handled the RPC
-        _LOGGER.warning('No subscriber handled RPC: %s', rpc_id)
-        response = make_rpc_response(rpc_id, self._client_id, error='No handler registered')
-        self._send(response)
+            _LOGGER.debug('RPC completed: %s', rpc_id)
+
+        except Exception as exc:
+            _LOGGER.exception('RPC subscriber %s failed: %s', recipient, exc)
+            response = make_rpc_response(rpc_id, self._client_id, error=str(exc))
+            self._send(response)
 
     def _handle_rpc_response(self, msg: dict) -> None:
         """Handle RPC response from broker."""

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -178,10 +178,12 @@ class ZmqCommunicator:
             self._poller = None
 
         if self._dealer:
+            self._dealer.setsockopt(zmq.LINGER, 0)
             self._dealer.close()
             self._dealer = None
 
         if self._sub:
+            self._sub.setsockopt(zmq.LINGER, 0)
             self._sub.close()
             self._sub = None
 

--- a/src/aiida/brokers/zmq/communicator.py
+++ b/src/aiida/brokers/zmq/communicator.py
@@ -12,7 +12,6 @@ import zmq
 
 from aiida.brokers.utils import YAML_DECODER, YAML_ENCODER
 
-from .defaults import RPC_TIMEOUT
 from .protocol import (
     MessageType,
     decode_message,
@@ -522,6 +521,32 @@ class ZmqCommunicator:
         for task_id in completed:
             del self._in_progress_tasks[task_id]
 
+    def _send_rpc_result(self, rpc_id: str, result: Any) -> None:
+        """Send an RPC response, resolving Futures if needed.
+
+        For RPCs whose result is a Future (e.g. plumpy's ``_schedule_rpc``),
+        we cannot serialize the Future directly.  Instead we attach a callback
+        so the response is sent once the Future resolves.
+        """
+        if isinstance(result, Future):
+            def _on_done(fut: Future) -> None:
+                try:
+                    resolved = fut.result()
+                    # The resolved value may itself be a Future (chained)
+                    self._send_rpc_result(rpc_id, resolved)
+                except Exception as exc:
+                    _LOGGER.exception('RPC %s future failed: %s', rpc_id, exc)
+                    try:
+                        response = make_rpc_response(rpc_id, self._client_id, error=str(exc))
+                        self._send(response)
+                    except Exception:
+                        pass
+
+            result.add_done_callback(_on_done)
+        else:
+            response = make_rpc_response(rpc_id, self._client_id, result=result)
+            self._send(response)
+
     def _send_task_result(self, task_id: str, result: Any) -> None:
         """Send a task response, resolving Futures if needed.
 
@@ -594,21 +619,8 @@ class ZmqCommunicator:
 
         try:
             result = subscriber(self, body)
-
-            # Resolve Future(s) before serializing: plumpy subscribers
-            # (via convert_to_comm) return a kiwipy.Future whose result
-            # may itself be another Future (via plum_to_kiwi_future
-            # chaining). We resolve all layers to get a concrete value.
-            # Callers use unwrap_kiwi_future to handle both nested and
-            # flat responses, so fully resolving here is correct.
-            while isinstance(result, Future):
-                result = result.result(timeout=RPC_TIMEOUT)
-
-            # Send response
-            response = make_rpc_response(rpc_id, self._client_id, result=result)
-            self._send(response)
-
-            _LOGGER.debug('RPC completed: %s', rpc_id)
+            self._send_rpc_result(rpc_id, result)
+            _LOGGER.debug('RPC handled: %s', rpc_id)
 
         except Exception as exc:
             _LOGGER.exception('RPC subscriber %s failed: %s', recipient, exc)

--- a/src/aiida/brokers/zmq/controller.py
+++ b/src/aiida/brokers/zmq/controller.py
@@ -1,0 +1,331 @@
+"""ZMQ Broker Controller - client-side control for ZmqBrokerService.
+
+This module provides a client-side interface to interact with the broker service
+by reading PID/status files. Similar to AiiDA's DaemonClient pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    import psutil
+
+    HAS_PSUTIL = True
+except ImportError:
+    HAS_PSUTIL = False
+
+
+class ZmqBrokerController:
+    """Controller for ZmqBrokerService.
+
+    Allows external code to:
+    - Start/stop the broker service
+    - Check if service is running
+    - Get service status
+
+    Interacts with the service via PID/status files, not direct IPC.
+    """
+
+    def __init__(self, base_path: Path | str):
+        """Initialize the controller.
+
+        :param base_path: Base path for broker data (same as ZmqBrokerService)
+        """
+        self._base_path = Path(base_path)
+        self._pid_file = self._base_path / 'broker.pid'
+        self._status_file = self._base_path / 'broker.status'
+        self._sockets_file = self._base_path / 'broker.sockets'
+
+    @property
+    def base_path(self) -> Path:
+        """Return the base path for broker data."""
+        return self._base_path
+
+    @property
+    def pid_file(self) -> Path:
+        """Return the PID file path."""
+        return self._pid_file
+
+    @property
+    def status_file(self) -> Path:
+        """Return the status file path."""
+        return self._status_file
+
+    def _get_sockets_path(self) -> Path | None:
+        """Read the socket directory path from file.
+
+        The socket directory is created in a temp location by ZmqBrokerService
+        to avoid Unix domain socket path length limits.
+
+        :return: Path to socket directory, or None if not available
+        """
+        if not self._sockets_file.exists():
+            return None
+        try:
+            return Path(self._sockets_file.read_text().strip())
+        except OSError:
+            return None
+
+    @property
+    def router_endpoint(self) -> str | None:
+        """Return the ROUTER socket endpoint.
+
+        :return: Endpoint string, or None if broker is not running
+        """
+        sockets_path = self._get_sockets_path()
+        if sockets_path is None:
+            return None
+        return f'ipc://{sockets_path}/router.sock'
+
+    @property
+    def pub_endpoint(self) -> str | None:
+        """Return the PUB socket endpoint.
+
+        :return: Endpoint string, or None if broker is not running
+        """
+        sockets_path = self._get_sockets_path()
+        if sockets_path is None:
+            return None
+        return f'ipc://{sockets_path}/pub.sock'
+
+    def get_pid(self) -> int | None:
+        """Get broker PID from file.
+
+        :return: PID if file exists and is valid, None otherwise
+        """
+        if not self._pid_file.exists():
+            return None
+
+        try:
+            pid_str = self._pid_file.read_text().strip()
+            return int(pid_str)
+        except (ValueError, OSError):
+            return None
+
+    def _validate_pid(self, pid: int) -> bool:
+        """Validate that PID is a running broker process.
+
+        :param pid: Process ID to validate
+        :return: True if PID is valid and running
+        """
+        if HAS_PSUTIL:
+            try:
+                proc = psutil.Process(pid)
+                # Check if process is running and is a Python process
+                if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+                    # Verify it's our broker by checking command line
+                    cmdline = proc.cmdline()
+                    return any('aiida.brokers.zmq' in arg for arg in cmdline)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                return False
+        else:
+            # Fallback: just check if process exists
+            try:
+                os.kill(pid, 0)
+                return True
+            except OSError:
+                return False
+
+        return False
+
+    def is_running(self) -> bool:
+        """Check if broker service is running.
+
+        Validates that:
+        1. PID file exists
+        2. PID in file corresponds to a running broker process
+
+        :return: True if service is running
+        """
+        pid = self.get_pid()
+        if pid is None:
+            return False
+
+        return self._validate_pid(pid)
+
+    def get_status(self) -> dict[str, Any] | None:
+        """Read status from file.
+
+        :return: Status dictionary or None if not available
+        """
+        if not self._status_file.exists():
+            return None
+
+        try:
+            return json.loads(self._status_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def start(self, foreground: bool = False, wait: bool = True, timeout: float = 10.0) -> bool:
+        """Start the broker service.
+
+        :param foreground: If True, run in foreground (blocking); else daemonize
+        :param wait: If True and not foreground, wait for service to start
+        :param timeout: Timeout in seconds when waiting for service to start
+        :return: True if service started successfully
+        """
+        if self.is_running():
+            return True
+
+        # Ensure base path exists
+        self._base_path.mkdir(parents=True, exist_ok=True)
+
+        # Build command
+        cmd = [
+            sys.executable,
+            '-m',
+            'aiida.brokers.zmq.service',
+            '--base-path',
+            str(self._base_path),
+        ]
+
+        if foreground:
+            # Run in foreground (blocking)
+            subprocess.run(cmd, check=True)
+            return True
+        else:
+            # Run as daemon (detached process)
+            # Use subprocess with appropriate flags for daemon behavior
+            if sys.platform == 'win32':
+                # Windows: use CREATE_NEW_PROCESS_GROUP
+                subprocess.Popen(
+                    cmd,
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    stdin=subprocess.DEVNULL,
+                )
+            else:
+                # Unix: use start_new_session
+                subprocess.Popen(
+                    cmd,
+                    start_new_session=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    stdin=subprocess.DEVNULL,
+                )
+
+            if wait:
+                return self._wait_for_start(timeout)
+
+            return True
+
+    def _wait_for_start(self, timeout: float) -> bool:
+        """Wait for service to start.
+
+        :param timeout: Timeout in seconds
+        :return: True if service started within timeout
+        """
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if self.is_running():
+                return True
+            time.sleep(0.1)
+        return False
+
+    def stop(self, timeout: float = 5.0) -> bool:
+        """Stop the broker service.
+
+        Uses SIGINT for cross-platform graceful shutdown.
+        Falls back to hard kill if timeout expires.
+
+        :param timeout: Seconds to wait for graceful shutdown
+        :return: True if stopped successfully
+        """
+        pid = self.get_pid()
+        if pid is None:
+            return True
+
+        if not self._validate_pid(pid):
+            # PID file exists but process is not running, clean up
+            self._cleanup_stale_files()
+            return True
+
+        # Send SIGINT for graceful shutdown (works on all platforms)
+        try:
+            os.kill(pid, signal.SIGINT)
+        except OSError:
+            # Process already gone
+            self._cleanup_stale_files()
+            return True
+
+        # Wait for graceful shutdown
+        if self._wait_for_stop(pid, timeout):
+            return True
+
+        # Graceful shutdown failed, try hard kill
+        return self._force_kill(pid)
+
+    def _wait_for_stop(self, pid: int, timeout: float) -> bool:
+        """Wait for process to stop.
+
+        :param pid: Process ID
+        :param timeout: Timeout in seconds
+        :return: True if process stopped within timeout
+        """
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if not self._validate_pid(pid):
+                self._cleanup_stale_files()
+                return True
+            time.sleep(0.1)
+        return False
+
+    def _force_kill(self, pid: int) -> bool:
+        """Force kill a process.
+
+        :param pid: Process ID
+        :return: True if killed successfully
+        """
+        if HAS_PSUTIL:
+            try:
+                proc = psutil.Process(pid)
+                proc.terminate()  # Sends SIGTERM on Unix, TerminateProcess on Windows
+                proc.wait(timeout=2.0)
+                self._cleanup_stale_files()
+                return True
+            except (psutil.NoSuchProcess, psutil.TimeoutExpired):
+                try:
+                    proc.kill()  # SIGKILL on Unix, TerminateProcess on Windows
+                    self._cleanup_stale_files()
+                    return True
+                except psutil.NoSuchProcess:
+                    self._cleanup_stale_files()
+                    return True
+            except psutil.AccessDenied:
+                return False
+        else:
+            # Without psutil, try SIGKILL on Unix (not available on Windows)
+            if sys.platform != 'win32':
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                    self._cleanup_stale_files()
+                    return True
+                except OSError:
+                    self._cleanup_stale_files()
+                    return True
+            return False  # type: ignore[unreachable]  # Windows without psutil
+
+    def _cleanup_stale_files(self) -> None:
+        """Clean up stale PID and status files."""
+        if self._pid_file.exists():
+            self._pid_file.unlink(missing_ok=True)
+        if self._status_file.exists():
+            self._status_file.unlink(missing_ok=True)
+
+    def restart(self, timeout: float = 5.0) -> bool:
+        """Restart the broker service.
+
+        :param timeout: Timeout for stop operation
+        :return: True if restarted successfully
+        """
+        self.stop(timeout=timeout)
+        return self.start(wait=True)

--- a/src/aiida/brokers/zmq/defaults.py
+++ b/src/aiida/brokers/zmq/defaults.py
@@ -6,7 +6,12 @@ from typing import Any
 
 from aiida.common.extendeddicts import AttributeDict
 
-__all__ = ('BROKER_DEFAULTS', 'get_zmq_config')
+__all__ = ('BROKER_DEFAULTS', 'RPC_TIMEOUT', 'get_zmq_config')
+
+# Timeout (in seconds) for waiting on RPC Future results in the poll thread.
+# None means no timeout, matching kiwipy RMQ behavior where _on_rpc awaits
+# without a deadline. The runner event loop will eventually produce a result.
+RPC_TIMEOUT: float | None = None
 
 # ZMQ broker uses local IPC sockets, minimal configuration needed
 # Paths are derived from profile UUID at runtime

--- a/src/aiida/brokers/zmq/defaults.py
+++ b/src/aiida/brokers/zmq/defaults.py
@@ -1,0 +1,24 @@
+"""Default configuration for ZMQ broker."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiida.common.extendeddicts import AttributeDict
+
+__all__ = ('BROKER_DEFAULTS', 'get_zmq_config')
+
+# ZMQ broker uses local IPC sockets, minimal configuration needed
+# Paths are derived from profile UUID at runtime
+BROKER_DEFAULTS = AttributeDict({})
+
+
+def get_zmq_config() -> dict[str, Any]:
+    """Return ZMQ broker configuration.
+
+    ZMQ broker uses profile-derived paths, so minimal configuration is needed.
+    The actual paths are computed from the profile UUID in ZmqBroker.__init__.
+
+    :return: Empty configuration dictionary
+    """
+    return {}

--- a/src/aiida/brokers/zmq/protocol.py
+++ b/src/aiida/brokers/zmq/protocol.py
@@ -174,7 +174,7 @@ def make_rpc_response(rpc_id: str, sender: str, result: Any = None, error: str |
 
 
 def make_broadcast_message(
-    body: Any, sender: str, subject: str | None = None, correlation_id: str | None = None
+    body: Any, sender: str | uuid.UUID, subject: str | None = None, correlation_id: str | None = None
 ) -> dict:
     """Create a broadcast message dictionary."""
     return {

--- a/src/aiida/brokers/zmq/protocol.py
+++ b/src/aiida/brokers/zmq/protocol.py
@@ -1,0 +1,197 @@
+"""Message protocol definitions for ZMQ broker."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class MessageType(str, Enum):
+    """Message types for the ZMQ broker protocol."""
+
+    # Task messages
+    TASK = 'task'
+    TASK_RESPONSE = 'task_response'
+    TASK_ACK = 'task_ack'
+    TASK_NACK = 'task_nack'
+
+    # RPC messages
+    RPC = 'rpc'
+    RPC_RESPONSE = 'rpc_response'
+
+    # Broadcast messages
+    BROADCAST = 'broadcast'
+
+    # Subscription management
+    SUBSCRIBE_TASK = 'subscribe_task'
+    SUBSCRIBE_RPC = 'subscribe_rpc'
+    UNSUBSCRIBE_TASK = 'unsubscribe_task'
+    UNSUBSCRIBE_RPC = 'unsubscribe_rpc'
+
+
+@dataclass
+class Message:
+    """Base message structure."""
+
+    type: MessageType
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    sender: str = ''
+
+
+@dataclass
+class TaskMessage(Message):
+    """Task message sent to the broker for processing."""
+
+    type: MessageType = field(default=MessageType.TASK, init=False)
+    body: Any = None
+    no_reply: bool = False
+
+
+@dataclass
+class TaskResponse(Message):
+    """Response to a task message."""
+
+    type: MessageType = field(default=MessageType.TASK_RESPONSE, init=False)
+    task_id: str = ''
+    result: Any = None
+    error: str | None = None
+
+
+@dataclass
+class RpcMessage(Message):
+    """RPC message sent to a specific recipient."""
+
+    type: MessageType = field(default=MessageType.RPC, init=False)
+    recipient: str = ''
+    body: Any = None
+
+
+@dataclass
+class RpcResponse(Message):
+    """Response to an RPC message."""
+
+    type: MessageType = field(default=MessageType.RPC_RESPONSE, init=False)
+    rpc_id: str = ''
+    result: Any = None
+    error: str | None = None
+
+
+@dataclass
+class BroadcastMessage(Message):
+    """Broadcast message sent to all subscribers."""
+
+    type: MessageType = field(default=MessageType.BROADCAST, init=False)
+    body: Any = None
+    subject: str | None = None
+    correlation_id: str | None = None
+
+
+@dataclass
+class SubscribeMessage(Message):
+    """Subscription request message."""
+
+    type: MessageType = MessageType.SUBSCRIBE_TASK
+    identifier: str | None = None
+
+
+def encode_message(msg: dict, encoder=json.dumps) -> bytes:
+    """Encode a message dictionary to bytes."""
+    return encoder(msg).encode('utf-8')
+
+
+def decode_message(data: bytes, decoder=json.loads) -> dict:
+    """Decode bytes to a message dictionary."""
+    return decoder(data.decode('utf-8'))
+
+
+def make_task_message(body: Any, sender: str, no_reply: bool = False) -> dict:
+    """Create a task message dictionary."""
+    return {
+        'type': MessageType.TASK.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'body': body,
+        'no_reply': no_reply,
+    }
+
+
+def make_task_response(task_id: str, sender: str, result: Any = None, error: str | None = None) -> dict:
+    """Create a task response dictionary."""
+    return {
+        'type': MessageType.TASK_RESPONSE.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'task_id': task_id,
+        'result': result,
+        'error': error,
+    }
+
+
+def make_task_ack(task_id: str, sender: str) -> dict:
+    """Create a task acknowledgment message."""
+    return {
+        'type': MessageType.TASK_ACK.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'task_id': task_id,
+    }
+
+
+def make_task_nack(task_id: str, sender: str) -> dict:
+    """Create a task negative acknowledgment message."""
+    return {
+        'type': MessageType.TASK_NACK.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'task_id': task_id,
+    }
+
+
+def make_rpc_message(recipient: str, body: Any, sender: str) -> dict:
+    """Create an RPC message dictionary."""
+    return {
+        'type': MessageType.RPC.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'recipient': recipient,
+        'body': body,
+    }
+
+
+def make_rpc_response(rpc_id: str, sender: str, result: Any = None, error: str | None = None) -> dict:
+    """Create an RPC response dictionary."""
+    return {
+        'type': MessageType.RPC_RESPONSE.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'rpc_id': rpc_id,
+        'result': result,
+        'error': error,
+    }
+
+
+def make_broadcast_message(
+    body: Any, sender: str, subject: str | None = None, correlation_id: str | None = None
+) -> dict:
+    """Create a broadcast message dictionary."""
+    return {
+        'type': MessageType.BROADCAST.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'body': body,
+        'subject': subject,
+        'correlation_id': correlation_id,
+    }
+
+
+def make_subscribe_message(msg_type: MessageType, sender: str, identifier: str | None = None) -> dict:
+    """Create a subscription message dictionary."""
+    return {
+        'type': msg_type.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
+        'identifier': identifier,
+    }

--- a/src/aiida/brokers/zmq/protocol.py
+++ b/src/aiida/brokers/zmq/protocol.py
@@ -17,7 +17,6 @@ class MessageType(str, Enum):
     TASK_RESPONSE = 'task_response'
     TASK_ACK = 'task_ack'
     TASK_NACK = 'task_nack'
-
     # RPC messages
     RPC = 'rpc'
     RPC_RESPONSE = 'rpc_response'
@@ -30,6 +29,9 @@ class MessageType(str, Enum):
     SUBSCRIBE_RPC = 'subscribe_rpc'
     UNSUBSCRIBE_TASK = 'unsubscribe_task'
     UNSUBSCRIBE_RPC = 'unsubscribe_rpc'
+
+    # Health check
+    PING = 'ping'
 
 
 @dataclass
@@ -147,6 +149,15 @@ def make_task_nack(task_id: str, sender: str) -> dict:
         'id': uuid.uuid4().hex,
         'sender': sender,
         'task_id': task_id,
+    }
+
+
+def make_ping(sender: str) -> dict:
+    """Create a ping message for worker liveness probing."""
+    return {
+        'type': MessageType.PING.value,
+        'id': uuid.uuid4().hex,
+        'sender': sender,
     }
 
 

--- a/src/aiida/brokers/zmq/queue.py
+++ b/src/aiida/brokers/zmq/queue.py
@@ -217,6 +217,21 @@ class PersistentQueue:
         _LOGGER.info('Cleared %d pending tasks', count)
         return count
 
+    def remove_pending(self, task_id: str) -> bool:
+        """Remove a pending task by its ID without processing it.
+
+        :param task_id: ID of the task to remove
+        :return: True if the task was removed, False if not found
+        """
+        for filename in self._pending:
+            if self._extract_task_id(filename) == task_id:
+                task_file = self._pending_path / filename
+                task_file.unlink(missing_ok=True)
+                self._pending.remove(filename)
+                _LOGGER.debug('Removed pending task %s', task_id)
+                return True
+        return False
+
     def get_all_pending(self) -> list[tuple[str, dict[str, Any]]]:
         """Get all pending tasks without removing them.
 

--- a/src/aiida/brokers/zmq/queue.py
+++ b/src/aiida/brokers/zmq/queue.py
@@ -1,0 +1,249 @@
+"""Persistent queue implementation for ZMQ broker."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PersistentQueue:
+    """Folder-based persistent task queue.
+
+    Tasks are stored as individual JSON files on disk for durability.
+    The filename encodes the timestamp and task ID for ordering.
+
+    Storage structure:
+        {storage_path}/
+        ├── pending/        # Tasks waiting to be processed
+        │   └── {timestamp}_{task_id}.json
+        └── processing/     # Tasks currently being processed (unacked)
+            └── {timestamp}_{task_id}.json
+    """
+
+    def __init__(self, storage_path: Path | str):
+        """Initialize the persistent queue.
+
+        :param storage_path: Path to the queue storage directory
+        """
+        self._storage_path = Path(storage_path)
+        self._pending_path = self._storage_path / 'pending'
+        self._processing_path = self._storage_path / 'processing'
+
+        # In-memory tracking
+        self._pending: list[str] = []  # List of task filenames in order
+        self._processing: dict[str, str] = {}  # task_id -> filename
+
+        # Ensure directories exist
+        self._pending_path.mkdir(parents=True, exist_ok=True)
+        self._processing_path.mkdir(parents=True, exist_ok=True)
+
+        # Load existing tasks from disk
+        self._load()
+
+    def _load(self) -> None:
+        """Load pending and processing tasks from disk on startup.
+
+        Processing tasks are moved back to pending (crash recovery).
+        """
+        # Move any processing tasks back to pending (crash recovery)
+        for task_file in self._processing_path.glob('*.json'):
+            dest = self._pending_path / task_file.name
+            task_file.rename(dest)
+            _LOGGER.info('Recovered task from processing: %s', task_file.stem)
+
+        # Load pending tasks in timestamp order
+        pending_files = sorted(self._pending_path.glob('*.json'))
+        for task_file in pending_files:
+            self._pending.append(task_file.name)
+
+        _LOGGER.info('Loaded %d pending tasks from disk', len(self._pending))
+
+    def _make_filename(self, task_id: str) -> str:
+        """Create a filename with timestamp prefix for ordering."""
+        timestamp = int(time.time() * 1000000)  # Microseconds for uniqueness
+        return f'{timestamp}_{task_id}.json'
+
+    def _extract_task_id(self, filename: str) -> str:
+        """Extract task ID from filename."""
+        # Format: {timestamp}_{task_id}.json
+        return filename.rsplit('.', 1)[0].split('_', 1)[1]
+
+    def push(self, task_id: str, task: dict[str, Any]) -> None:
+        """Add a task to the queue.
+
+        The task is immediately persisted to disk.
+
+        :param task_id: Unique identifier for the task
+        :param task: Task data dictionary
+        """
+        filename = self._make_filename(task_id)
+        task_file = self._pending_path / filename
+
+        # Write atomically by writing to temp file then renaming
+        temp_file = task_file.with_suffix('.tmp')
+        temp_file.write_text(json.dumps(task, indent=2))
+        temp_file.rename(task_file)
+
+        self._pending.append(filename)
+        _LOGGER.debug('Queued task %s', task_id)
+
+    def pop(self) -> tuple[str, dict[str, Any]] | None:
+        """Get the next task from the queue.
+
+        The task is moved to the processing state until acked or nacked.
+
+        :return: Tuple of (task_id, task_data) or None if queue is empty
+        """
+        if not self._pending:
+            return None
+
+        filename = self._pending.pop(0)
+        task_id = self._extract_task_id(filename)
+
+        # Move from pending to processing
+        src = self._pending_path / filename
+        dest = self._processing_path / filename
+
+        try:
+            task = json.loads(src.read_text())
+            src.rename(dest)
+            self._processing[task_id] = filename
+            _LOGGER.debug('Dequeued task %s', task_id)
+            return task_id, task
+        except FileNotFoundError:
+            _LOGGER.warning('Task file not found: %s', filename)
+            return self.pop()  # Try next task
+        except json.JSONDecodeError as exc:
+            _LOGGER.error('Failed to decode task %s: %s', filename, exc)
+            src.unlink(missing_ok=True)  # Remove corrupted file
+            return self.pop()  # Try next task
+
+    def peek(self) -> tuple[str, dict[str, Any]] | None:
+        """Peek at the next task without removing it.
+
+        :return: Tuple of (task_id, task_data) or None if queue is empty
+        """
+        if not self._pending:
+            return None
+
+        filename = self._pending[0]
+        task_id = self._extract_task_id(filename)
+        task_file = self._pending_path / filename
+
+        try:
+            task = json.loads(task_file.read_text())
+            return task_id, task
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+    def ack(self, task_id: str) -> bool:
+        """Acknowledge successful processing of a task.
+
+        Removes the task from disk.
+
+        :param task_id: ID of the task to acknowledge
+        :return: True if task was acknowledged, False if not found
+        """
+        filename = self._processing.pop(task_id, None)
+        if filename is None:
+            _LOGGER.warning('Cannot ack unknown task: %s', task_id)
+            return False
+
+        task_file = self._processing_path / filename
+        task_file.unlink(missing_ok=True)
+        _LOGGER.debug('Acked task %s', task_id)
+        return True
+
+    def nack(self, task_id: str, requeue: bool = True) -> bool:
+        """Negative acknowledgment - task processing failed.
+
+        :param task_id: ID of the task
+        :param requeue: If True, put task back in queue; if False, discard it
+        :return: True if task was nacked, False if not found
+        """
+        filename = self._processing.pop(task_id, None)
+        if filename is None:
+            _LOGGER.warning('Cannot nack unknown task: %s', task_id)
+            return False
+
+        task_file = self._processing_path / filename
+
+        if requeue:
+            # Move back to pending (at the front for retry)
+            dest = self._pending_path / filename
+            try:
+                task_file.rename(dest)
+                self._pending.insert(0, filename)
+                _LOGGER.debug('Nacked and requeued task %s', task_id)
+            except FileNotFoundError:
+                _LOGGER.warning('Task file not found for nack: %s', task_id)
+                return False
+        else:
+            # Just remove it
+            task_file.unlink(missing_ok=True)
+            _LOGGER.debug('Nacked and discarded task %s', task_id)
+
+        return True
+
+    def size(self) -> int:
+        """Return the number of pending tasks."""
+        return len(self._pending)
+
+    def processing_count(self) -> int:
+        """Return the number of tasks currently being processed."""
+        return len(self._processing)
+
+    def is_empty(self) -> bool:
+        """Check if the queue is empty."""
+        return len(self._pending) == 0
+
+    def clear(self) -> int:
+        """Remove all pending tasks from the queue.
+
+        Does not affect tasks currently being processed.
+
+        :return: Number of tasks removed
+        """
+        count = len(self._pending)
+        for filename in self._pending:
+            task_file = self._pending_path / filename
+            task_file.unlink(missing_ok=True)
+        self._pending.clear()
+        _LOGGER.info('Cleared %d pending tasks', count)
+        return count
+
+    def get_all_pending(self) -> list[tuple[str, dict[str, Any]]]:
+        """Get all pending tasks without removing them.
+
+        :return: List of (task_id, task_data) tuples
+        """
+        tasks = []
+        for filename in self._pending:
+            task_id = self._extract_task_id(filename)
+            task_file = self._pending_path / filename
+            try:
+                task = json.loads(task_file.read_text())
+                tasks.append((task_id, task))
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+        return tasks
+
+    def get_all_processing(self) -> list[tuple[str, dict[str, Any]]]:
+        """Get all tasks currently being processed.
+
+        :return: List of (task_id, task_data) tuples
+        """
+        tasks = []
+        for task_id, filename in self._processing.items():
+            task_file = self._processing_path / filename
+            try:
+                task = json.loads(task_file.read_text())
+                tasks.append((task_id, task))
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+        return tasks

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -1,0 +1,509 @@
+"""ZeroMQ Broker Server - standalone message broker.
+
+This module is completely independent of AiiDA and can be used as a standalone
+message broker server. It handles:
+- Task queue management with persistence
+- Request/reply routing for RPC
+- Broadcast distribution
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any, Callable
+
+import zmq
+
+from .protocol import MessageType, decode_message, encode_message
+from .queue import PersistentQueue
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ZmqBrokerServer:
+    """Standalone ZMQ message broker server.
+
+    Uses ROUTER socket for request-reply routing and PUB socket for broadcasts.
+
+    The server maintains:
+    - A persistent task queue for reliable task delivery
+    - RPC subscriber registry for routing RPC calls
+    - Task subscriber registry for distributing tasks
+
+    Socket architecture:
+        ROUTER (frontend) - Receives all client messages, routes replies
+        PUB (broadcast)   - Publishes broadcast messages to all subscribers
+    """
+
+    def __init__(
+        self,
+        storage_path: Path | str,
+        sockets_path: Path | str,
+        encoder: Callable[[Any], str] = json.dumps,
+        decoder: Callable[[str], Any] = json.loads,
+    ):
+        """Initialize the broker server.
+
+        :param storage_path: Path for task queue persistence
+        :param sockets_path: Path for IPC socket files
+        :param encoder: Function to encode messages to JSON string
+        :param decoder: Function to decode JSON string to messages
+        """
+        self._storage_path = Path(storage_path)
+        self._sockets_path = Path(sockets_path)
+
+        # Ensure directories exist
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+        self._sockets_path.mkdir(parents=True, exist_ok=True)
+
+        # Derive endpoints from sockets_path
+        self._router_endpoint = f'ipc://{self._sockets_path}/router.sock'
+        self._pub_endpoint = f'ipc://{self._sockets_path}/pub.sock'
+
+        self._encoder = encoder
+        self._decoder = decoder
+
+        # ZMQ context and sockets
+        self._context: zmq.Context | None = None
+        self._router: zmq.Socket | None = None
+        self._pub: zmq.Socket | None = None
+        self._poller: zmq.Poller | None = None
+
+        # Task queue with persistence
+        self._task_queue = PersistentQueue(self._storage_path / 'tasks')
+
+        # Subscriber registries
+        # task_subscribers: identifier -> client_identity (bytes)
+        self._task_subscribers: dict[str, bytes] = {}
+        # Available task workers (ready to receive tasks)
+        self._available_workers: deque[bytes] = deque()
+        # rpc_subscribers: identifier -> client_identity (bytes)
+        self._rpc_subscribers: dict[str, bytes] = {}
+
+        # Pending responses: correlation_id -> (client_identity, timestamp)
+        self._pending_task_responses: dict[str, tuple[bytes, float]] = {}
+        self._pending_rpc_responses: dict[str, tuple[bytes, float]] = {}
+
+        # Server state
+        self._running = False
+        self._lock = threading.Lock()
+
+    @property
+    def storage_path(self) -> Path:
+        """Return the path for task queue storage."""
+        return self._storage_path
+
+    @property
+    def sockets_path(self) -> Path:
+        """Return the path for socket files."""
+        return self._sockets_path
+
+    @property
+    def router_endpoint(self) -> str:
+        """Return the ROUTER socket endpoint."""
+        return self._router_endpoint
+
+    @property
+    def pub_endpoint(self) -> str:
+        """Return the PUB socket endpoint."""
+        return self._pub_endpoint
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether the server is running."""
+        return self._running
+
+    def start(self) -> None:
+        """Start the broker server.
+
+        Binds sockets and prepares for message handling.
+        """
+        if self._running:
+            return
+
+        _LOGGER.info('Starting ZMQ Broker Server')
+        _LOGGER.info('Storage path: %s', self._storage_path)
+        _LOGGER.info('ROUTER endpoint: %s', self._router_endpoint)
+        _LOGGER.info('PUB endpoint: %s', self._pub_endpoint)
+
+        # Create ZMQ context
+        self._context = zmq.Context()
+
+        # ROUTER socket for request-reply
+        self._router = self._context.socket(zmq.ROUTER)
+        self._router.bind(self._router_endpoint)
+
+        # PUB socket for broadcasts
+        self._pub = self._context.socket(zmq.PUB)
+        self._pub.bind(self._pub_endpoint)
+
+        # Set up poller
+        self._poller = zmq.Poller()
+        self._poller.register(self._router, zmq.POLLIN)
+
+        self._running = True
+        _LOGGER.info('ZMQ Broker Server started')
+
+    def stop(self) -> None:
+        """Stop the broker server.
+
+        Closes sockets and cleans up resources.
+        """
+        if not self._running:
+            return
+
+        _LOGGER.info('Stopping ZMQ Broker Server')
+        self._running = False
+
+        if self._poller:
+            self._poller.unregister(self._router)
+            self._poller = None
+
+        if self._router:
+            self._router.close()
+            self._router = None
+
+        if self._pub:
+            self._pub.close()
+            self._pub = None
+
+        if self._context:
+            self._context.term()
+            self._context = None
+
+        _LOGGER.info('ZMQ Broker Server stopped')
+
+    def run_forever(self, poll_timeout: int = 1000) -> None:
+        """Run the broker event loop.
+
+        Blocks until stop() is called or interrupted.
+
+        :param poll_timeout: Polling timeout in milliseconds
+        """
+        self.start()
+
+        try:
+            while self._running:
+                self._poll_once(poll_timeout)
+        finally:
+            self.stop()
+
+    def run_once(self, timeout: int = 0) -> bool:
+        """Process a single message if available.
+
+        :param timeout: Timeout in milliseconds (0 = non-blocking)
+        :return: True if a message was processed
+        """
+        if not self._running:
+            return False
+        return self._poll_once(timeout)
+
+    def _poll_once(self, timeout: int) -> bool:
+        """Poll for messages and handle one if available."""
+        if not self._poller:
+            return False
+
+        try:
+            socks = dict(self._poller.poll(timeout))
+        except zmq.ZMQError:
+            return False
+
+        if self._router in socks:
+            self._handle_router_message()
+            return True
+
+        # Try to dispatch pending tasks to available workers
+        self._dispatch_pending_tasks()
+        return False
+
+    def _handle_router_message(self) -> None:
+        """Handle a message from the ROUTER socket."""
+        if not self._router:
+            return
+
+        try:
+            # ROUTER socket prepends identity frame
+            frames = self._router.recv_multipart()
+            if len(frames) < 2:
+                _LOGGER.warning('Invalid message: insufficient frames')
+                return
+
+            identity = frames[0]
+            # Skip empty delimiter frame if present
+            msg_frame = frames[2] if len(frames) > 2 and frames[1] == b'' else frames[1]
+
+            msg = decode_message(msg_frame, self._decoder)
+            msg_type: str | None = msg.get('type')
+
+            _LOGGER.debug('Received %s from %s', msg_type, identity.hex()[:8])
+
+            if msg_type is None:
+                _LOGGER.warning('Message missing type field')
+                return
+
+            # Route by message type
+            handlers: dict[str, Any] = {
+                MessageType.TASK.value: self._handle_task,
+                MessageType.TASK_RESPONSE.value: self._handle_task_response,
+                MessageType.TASK_ACK.value: self._handle_task_ack,
+                MessageType.TASK_NACK.value: self._handle_task_nack,
+                MessageType.RPC.value: self._handle_rpc,
+                MessageType.RPC_RESPONSE.value: self._handle_rpc_response,
+                MessageType.BROADCAST.value: self._handle_broadcast,
+                MessageType.SUBSCRIBE_TASK.value: self._handle_subscribe_task,
+                MessageType.SUBSCRIBE_RPC.value: self._handle_subscribe_rpc,
+                MessageType.UNSUBSCRIBE_TASK.value: self._handle_unsubscribe_task,
+                MessageType.UNSUBSCRIBE_RPC.value: self._handle_unsubscribe_rpc,
+            }
+
+            handler = handlers.get(msg_type)
+            if handler:
+                handler(identity, msg)
+            else:
+                _LOGGER.warning('Unknown message type: %s', msg_type)
+
+        except Exception as exc:
+            _LOGGER.exception('Error handling router message: %s', exc)
+
+    def _handle_task(self, identity: bytes, msg: dict) -> None:
+        """Handle incoming task message.
+
+        Queue the task and try to dispatch to an available worker.
+        """
+        task_id = msg['id']
+        sender = msg.get('sender', '')
+        no_reply = msg.get('no_reply', False)
+
+        # Store task in persistent queue
+        task_data = {
+            'id': task_id,
+            'sender': sender,
+            'sender_identity': identity.hex(),
+            'body': msg.get('body'),
+            'no_reply': no_reply,
+            'timestamp': time.time(),
+        }
+        self._task_queue.push(task_id, task_data)
+
+        # Track pending response if reply expected
+        if not no_reply:
+            self._pending_task_responses[task_id] = (identity, time.time())
+
+        # Try to dispatch immediately
+        self._dispatch_pending_tasks()
+
+    def _handle_task_response(self, identity: bytes, msg: dict) -> None:
+        """Handle task response from worker.
+
+        Route the response back to the original task sender.
+        """
+        task_id = msg.get('task_id')
+        if not task_id:
+            _LOGGER.warning('Task response missing task_id')
+            return
+
+        # Find original sender
+        pending = self._pending_task_responses.pop(task_id, None)
+        if not pending:
+            _LOGGER.warning('No pending response for task: %s', task_id)
+            return
+
+        original_sender, _ = pending
+
+        # Forward response to original sender
+        self._send_to_client(original_sender, msg)
+
+    def _handle_task_ack(self, identity: bytes, msg: dict) -> None:
+        """Handle task acknowledgment from worker."""
+        task_id = msg.get('task_id')
+        if task_id:
+            self._task_queue.ack(task_id)
+            _LOGGER.debug('Task acknowledged: %s', task_id)
+
+        # Worker is available for more tasks
+        self._mark_worker_available(identity)
+
+    def _handle_task_nack(self, identity: bytes, msg: dict) -> None:
+        """Handle task negative acknowledgment from worker."""
+        task_id = msg.get('task_id')
+        if task_id:
+            self._task_queue.nack(task_id, requeue=True)
+            _LOGGER.debug('Task nacked and requeued: %s', task_id)
+
+        # Worker is available for more tasks
+        self._mark_worker_available(identity)
+
+    def _handle_rpc(self, identity: bytes, msg: dict) -> None:
+        """Handle RPC message.
+
+        Route to the specified recipient.
+        """
+        rpc_id = msg['id']
+        recipient = msg.get('recipient')
+
+        if not recipient:
+            _LOGGER.warning('RPC message missing recipient')
+            self._send_rpc_error(identity, rpc_id, 'Missing recipient')
+            return
+
+        # Find recipient identity
+        recipient_identity = self._rpc_subscribers.get(recipient)
+        if not recipient_identity:
+            _LOGGER.warning('RPC recipient not found: %s', recipient)
+            self._send_rpc_error(identity, rpc_id, f'Recipient not found: {recipient}')
+            return
+
+        # Track pending response
+        self._pending_rpc_responses[rpc_id] = (identity, time.time())
+
+        # Forward to recipient
+        self._send_to_client(recipient_identity, msg)
+
+    def _handle_rpc_response(self, identity: bytes, msg: dict) -> None:
+        """Handle RPC response.
+
+        Route back to original caller.
+        """
+        rpc_id = msg.get('rpc_id')
+        if not rpc_id:
+            _LOGGER.warning('RPC response missing rpc_id')
+            return
+
+        # Find original sender
+        pending = self._pending_rpc_responses.pop(rpc_id, None)
+        if not pending:
+            _LOGGER.warning('No pending response for RPC: %s', rpc_id)
+            return
+
+        original_sender, _ = pending
+
+        # Forward response to original sender
+        self._send_to_client(original_sender, msg)
+
+    def _handle_broadcast(self, identity: bytes, msg: dict) -> None:
+        """Handle broadcast message.
+
+        Publish to all subscribers via PUB socket.
+        """
+        if not self._pub:
+            return
+
+        # Publish on PUB socket
+        encoded = encode_message(msg, self._encoder)
+        self._pub.send(encoded)
+        _LOGGER.debug('Broadcast sent: %s', msg.get('subject', 'no subject'))
+
+    def _handle_subscribe_task(self, identity: bytes, msg: dict) -> None:
+        """Handle task subscriber registration."""
+        identifier = msg.get('identifier') or msg.get('sender')
+        if not identifier:
+            _LOGGER.warning('Task subscription missing identifier')
+            return
+
+        self._task_subscribers[identifier] = identity
+        self._mark_worker_available(identity)
+        _LOGGER.info('Task subscriber registered: %s', identifier)
+
+        # Try to dispatch any pending tasks
+        self._dispatch_pending_tasks()
+
+    def _handle_subscribe_rpc(self, identity: bytes, msg: dict) -> None:
+        """Handle RPC subscriber registration."""
+        identifier = msg.get('identifier') or msg.get('sender')
+        if not identifier:
+            _LOGGER.warning('RPC subscription missing identifier')
+            return
+
+        self._rpc_subscribers[identifier] = identity
+        _LOGGER.info('RPC subscriber registered: %s', identifier)
+
+    def _handle_unsubscribe_task(self, identity: bytes, msg: dict) -> None:
+        """Handle task subscriber removal."""
+        identifier = msg.get('identifier') or msg.get('sender')
+        if identifier and identifier in self._task_subscribers:
+            del self._task_subscribers[identifier]
+            _LOGGER.info('Task subscriber removed: %s', identifier)
+
+    def _handle_unsubscribe_rpc(self, identity: bytes, msg: dict) -> None:
+        """Handle RPC subscriber removal."""
+        identifier = msg.get('identifier') or msg.get('sender')
+        if identifier and identifier in self._rpc_subscribers:
+            del self._rpc_subscribers[identifier]
+            _LOGGER.info('RPC subscriber removed: %s', identifier)
+
+    def _dispatch_pending_tasks(self) -> None:
+        """Dispatch pending tasks to available workers."""
+        while self._available_workers and not self._task_queue.is_empty():
+            worker_identity = self._available_workers.popleft()
+
+            # Verify worker is still subscribed
+            if worker_identity not in self._task_subscribers.values():
+                continue
+
+            # Get next task
+            result = self._task_queue.pop()
+            if not result:
+                self._available_workers.appendleft(worker_identity)
+                break
+
+            task_id, task_data = result
+
+            # Send task to worker
+            task_msg = {
+                'type': MessageType.TASK.value,
+                'id': task_id,
+                'body': task_data.get('body'),
+                'no_reply': task_data.get('no_reply', False),
+            }
+            self._send_to_client(worker_identity, task_msg)
+            _LOGGER.debug('Dispatched task %s to worker', task_id)
+
+    def _mark_worker_available(self, identity: bytes) -> None:
+        """Mark a worker as available for tasks."""
+        if identity not in self._available_workers:
+            self._available_workers.append(identity)
+
+    def _send_to_client(self, identity: bytes, msg: dict) -> None:
+        """Send a message to a specific client."""
+        if not self._router:
+            return
+
+        encoded = encode_message(msg, self._encoder)
+        self._router.send_multipart([identity, b'', encoded])
+
+    def _send_rpc_error(self, identity: bytes, rpc_id: str, error: str) -> None:
+        """Send an RPC error response."""
+        error_msg = {
+            'type': MessageType.RPC_RESPONSE.value,
+            'rpc_id': rpc_id,
+            'error': error,
+        }
+        self._send_to_client(identity, error_msg)
+
+    # === Status and monitoring ===
+
+    def get_status(self) -> dict:
+        """Get current broker status."""
+        return {
+            'running': self._running,
+            'pending_tasks': self._task_queue.size(),
+            'processing_tasks': self._task_queue.processing_count(),
+            'task_subscribers': len(self._task_subscribers),
+            'rpc_subscribers': len(self._rpc_subscribers),
+            'available_workers': len(self._available_workers),
+            'pending_task_responses': len(self._pending_task_responses),
+            'pending_rpc_responses': len(self._pending_rpc_responses),
+        }
+
+    def get_pending_tasks(self) -> list[tuple[str, dict]]:
+        """Get all pending tasks."""
+        return self._task_queue.get_all_pending()
+
+    def get_processing_tasks(self) -> list[tuple[str, dict]]:
+        """Get all tasks currently being processed."""
+        return self._task_queue.get_all_processing()

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -354,8 +354,9 @@ class ZmqBrokerServer:
             self._send_rpc_error(identity, rpc_id, 'Missing recipient')
             return
 
-        # Find recipient identity
-        recipient_identity = self._rpc_subscribers.get(recipient)
+        # Find recipient identity (convert to string for consistent lookup,
+        # since subscribers register with string identifiers)
+        recipient_identity = self._rpc_subscribers.get(str(recipient))
         if not recipient_identity:
             _LOGGER.warning('RPC recipient not found: %s', recipient)
             self._send_rpc_error(identity, rpc_id, f'Recipient not found: {recipient}')

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -9,7 +9,6 @@ message broker server. It handles:
 
 from __future__ import annotations
 
-import json
 import logging
 import threading
 import time
@@ -18,6 +17,8 @@ from pathlib import Path
 from typing import Any, Callable
 
 import zmq
+
+from aiida.brokers.utils import YAML_DECODER, YAML_ENCODER
 
 from .protocol import MessageType, decode_message, encode_message
 from .queue import PersistentQueue
@@ -44,16 +45,18 @@ class ZmqBrokerServer:
         self,
         storage_path: Path | str,
         sockets_path: Path | str,
-        encoder: Callable[[Any], str] = json.dumps,
-        decoder: Callable[[str], Any] = json.loads,
+        encoder: Callable[[Any], str] | None = None,
+        decoder: Callable[[str], Any] | None = None,
     ):
         """Initialize the broker server.
 
         :param storage_path: Path for task queue persistence
         :param sockets_path: Path for IPC socket files
-        :param encoder: Function to encode messages to JSON string
-        :param decoder: Function to decode JSON string to messages
+        :param encoder: Function to encode messages (default: yaml.dump)
+        :param decoder: Function to decode messages (default: yaml.load)
         """
+        encoder = encoder if encoder is not None else YAML_ENCODER
+        decoder = decoder if decoder is not None else YAML_DECODER
         self._storage_path = Path(storage_path)
         self._sockets_path = Path(sockets_path)
 

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -47,7 +47,6 @@ class ZmqBrokerServer:
         sockets_path: Path | str,
         encoder: Callable[[Any], str] | None = None,
         decoder: Callable[[str], Any] | None = None,
-        task_timeout: float = 10.0,
     ):
         """Initialize the broker server.
 
@@ -55,7 +54,6 @@ class ZmqBrokerServer:
         :param sockets_path: Path for IPC socket files
         :param encoder: Function to encode messages (default: yaml.dump)
         :param decoder: Function to decode messages (default: yaml.load)
-        :param task_timeout: Seconds before an unacked task is requeued (default: 10)
         """
         encoder = encoder if encoder is not None else YAML_ENCODER
         decoder = decoder if decoder is not None else YAML_DECODER
@@ -78,6 +76,7 @@ class ZmqBrokerServer:
         self._router: zmq.Socket | None = None
         self._pub: zmq.Socket | None = None
         self._poller: zmq.Poller | None = None
+        self._monitor: zmq.Socket | None = None
 
         # Task queue with persistence
         self._task_queue = PersistentQueue(self._storage_path / 'tasks')
@@ -94,9 +93,9 @@ class ZmqBrokerServer:
         self._pending_task_responses: dict[str, tuple[bytes, float]] = {}
         self._pending_rpc_responses: dict[str, tuple[bytes, float]] = {}
 
-        # Task timeout for redelivery: task_id -> dispatch_time
-        self._task_timeout = task_timeout
-        self._task_dispatch_times: dict[str, float] = {}
+        # Task-worker assignments: task_id -> worker_identity
+        # Used to requeue tasks when a worker dies
+        self._task_worker_assignments: dict[str, bytes] = {}
 
         # Server state
         self._running = False
@@ -146,6 +145,9 @@ class ZmqBrokerServer:
         # ROUTER socket for request-reply
         self._router = self._context.socket(zmq.ROUTER)
         self._router.setsockopt(zmq.ROUTER_MANDATORY, 1)
+        # ZMTP heartbeats for dead peer detection
+        self._router.setsockopt(zmq.HEARTBEAT_IVL, 2000)      # ping every 2s
+        self._router.setsockopt(zmq.HEARTBEAT_TIMEOUT, 6000)   # dead after 6s no response
         self._router.bind(self._router_endpoint)
 
         # PUB socket for broadcasts
@@ -155,6 +157,10 @@ class ZmqBrokerServer:
         # Set up poller
         self._poller = zmq.Poller()
         self._poller.register(self._router, zmq.POLLIN)
+
+        # Monitor for disconnect events (dead peer detection)
+        self._monitor = self._router.get_monitor_socket(zmq.EVENT_DISCONNECTED)
+        self._poller.register(self._monitor, zmq.POLLIN)
 
         self._running = True
         _LOGGER.info('ZMQ Broker Server started')
@@ -171,8 +177,14 @@ class ZmqBrokerServer:
         self._running = False
 
         if self._poller:
+            if self._monitor:
+                self._poller.unregister(self._monitor)
             self._poller.unregister(self._router)
             self._poller = None
+
+        if self._monitor:
+            self._monitor.close()
+            self._monitor = None
 
         if self._router:
             self._router.close()
@@ -223,16 +235,18 @@ class ZmqBrokerServer:
         except zmq.ZMQError:
             return False
 
+        handled = False
+
         if self._router in socks:
             self._handle_router_message()
-            return True
+            handled = True
 
-        # Requeue tasks stuck in processing beyond the timeout
-        self._requeue_timed_out_tasks()
+        if self._monitor in socks:
+            self._handle_disconnect_event()
 
         # Try to dispatch pending tasks to available workers
         self._dispatch_pending_tasks()
-        return False
+        return handled
 
     def _handle_router_message(self) -> None:
         """Handle a message from the ROUTER socket."""
@@ -336,7 +350,7 @@ class ZmqBrokerServer:
         task_id = msg.get('task_id')
         if task_id:
             self._task_queue.ack(task_id)
-            self._task_dispatch_times.pop(task_id, None)
+            self._task_worker_assignments.pop(task_id, None)
             _LOGGER.debug('Task acknowledged: %s', task_id)
 
         # Worker is available for more tasks
@@ -458,26 +472,6 @@ class ZmqBrokerServer:
             del self._rpc_subscribers[identifier]
             _LOGGER.info('RPC subscriber removed: %s', identifier)
 
-    def _requeue_timed_out_tasks(self) -> None:
-        """Requeue tasks that have been in processing beyond the timeout.
-
-        This handles the case where a worker received a task but crashed
-        before sending an ACK.
-        """
-        if not self._task_dispatch_times:
-            return
-
-        now = time.time()
-        timed_out = [
-            task_id for task_id, dispatch_time in self._task_dispatch_times.items()
-            if now - dispatch_time > self._task_timeout
-        ]
-
-        for task_id in timed_out:
-            self._task_dispatch_times.pop(task_id, None)
-            self._task_queue.nack(task_id, requeue=True)
-            _LOGGER.warning('Task %s timed out after %.1fs, requeued', task_id, self._task_timeout)
-
     def _dispatch_pending_tasks(self) -> None:
         """Dispatch pending tasks to available workers."""
         while self._available_workers and not self._task_queue.is_empty():
@@ -511,11 +505,22 @@ class ZmqBrokerServer:
                 self._task_queue.nack(task_id, requeue=True)
                 self._remove_dead_worker(worker_identity)
                 continue
-            self._task_dispatch_times[task_id] = time.time()
+            self._task_worker_assignments[task_id] = worker_identity
+            # Re-add worker so it can receive more tasks concurrently
+            # (matching RMQ's multi-prefetch behaviour).  The ACK only
+            # affects the PersistentQueue, not worker availability.
+            self._mark_worker_available(worker_identity)
             _LOGGER.debug('Dispatched task %s to worker', task_id)
 
     def _remove_dead_worker(self, identity: bytes) -> None:
-        """Remove a disconnected worker from all registries."""
+        """Remove a disconnected worker from all registries and requeue its tasks."""
+        # Requeue all tasks assigned to this worker
+        dead_tasks = [tid for tid, wid in self._task_worker_assignments.items() if wid == identity]
+        for task_id in dead_tasks:
+            self._task_worker_assignments.pop(task_id, None)
+            self._task_queue.nack(task_id, requeue=True)
+            _LOGGER.warning('Requeued task %s from dead worker %s', task_id, identity.hex()[:8])
+
         # Remove from task subscribers
         dead_keys = [k for k, v in self._task_subscribers.items() if v == identity]
         for key in dead_keys:
@@ -530,6 +535,49 @@ class ZmqBrokerServer:
 
         # Remove from available workers
         self._available_workers = deque(w for w in self._available_workers if w != identity)
+
+    def _handle_disconnect_event(self) -> None:
+        """Handle a disconnect event from the socket monitor.
+
+        ZMTP heartbeat detected a dead peer. We don't know which identity
+        disconnected (monitor only provides endpoint/fd), so we probe all
+        workers with in-progress tasks to find the dead one.
+        """
+        if not self._monitor:
+            return
+
+        # Read and discard the monitor event
+        try:
+            from zmq.utils.monitor import recv_monitor_message
+            recv_monitor_message(self._monitor)
+        except Exception:
+            return
+
+        _LOGGER.info('Disconnect event detected, probing workers')
+        self._probe_workers()
+
+    def _probe_workers(self) -> None:
+        """Probe workers with in-progress tasks to find dead ones.
+
+        Sends a PING to each worker identity that has tasks assigned.
+        With ROUTER_MANDATORY, sending to a dead identity raises
+        ZMQError(EHOSTUNREACH), identifying the dead worker.
+        """
+        if not self._task_worker_assignments:
+            return
+
+        from .protocol import make_ping
+
+        # Get unique worker identities with assigned tasks
+        worker_identities = set(self._task_worker_assignments.values())
+
+        for identity in worker_identities:
+            try:
+                ping_msg = make_ping('broker')
+                self._send_to_client(identity, ping_msg)
+            except zmq.ZMQError:
+                _LOGGER.warning('Worker %s is dead, removing', identity.hex()[:8])
+                self._remove_dead_worker(identity)
 
     def _mark_worker_available(self, identity: bytes) -> None:
         """Mark a worker as available for tasks."""

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -139,6 +139,7 @@ class ZmqBrokerServer:
 
         # ROUTER socket for request-reply
         self._router = self._context.socket(zmq.ROUTER)
+        self._router.setsockopt(zmq.ROUTER_MANDATORY, 1)
         self._router.bind(self._router_endpoint)
 
         # PUB socket for broadcasts
@@ -366,7 +367,14 @@ class ZmqBrokerServer:
         self._pending_rpc_responses[rpc_id] = (identity, time.time())
 
         # Forward to recipient
-        self._send_to_client(recipient_identity, msg)
+        try:
+            self._send_to_client(recipient_identity, msg)
+        except zmq.ZMQError:
+            _LOGGER.warning('RPC recipient %s disconnected', recipient)
+            self._pending_rpc_responses.pop(rpc_id, None)
+            self._remove_dead_worker(recipient_identity)
+            self._send_rpc_error(identity, rpc_id, f'Recipient not found: {recipient}')
+            return
 
     def _handle_rpc_response(self, identity: bytes, msg: dict) -> None:
         """Handle RPC response.
@@ -464,8 +472,33 @@ class ZmqBrokerServer:
                 'body': task_data.get('body'),
                 'no_reply': task_data.get('no_reply', False),
             }
-            self._send_to_client(worker_identity, task_msg)
+            try:
+                self._send_to_client(worker_identity, task_msg)
+            except zmq.ZMQError:
+                # Worker disconnected — requeue the task and remove the
+                # dead worker so we don't keep trying to reach it.
+                _LOGGER.warning('Worker %s disconnected, requeuing task %s', worker_identity.hex()[:8], task_id)
+                self._task_queue.nack(task_id, requeue=True)
+                self._remove_dead_worker(worker_identity)
+                continue
             _LOGGER.debug('Dispatched task %s to worker', task_id)
+
+    def _remove_dead_worker(self, identity: bytes) -> None:
+        """Remove a disconnected worker from all registries."""
+        # Remove from task subscribers
+        dead_keys = [k for k, v in self._task_subscribers.items() if v == identity]
+        for key in dead_keys:
+            del self._task_subscribers[key]
+            _LOGGER.info('Removed dead task subscriber: %s', key)
+
+        # Remove from RPC subscribers
+        dead_keys = [k for k, v in self._rpc_subscribers.items() if v == identity]
+        for key in dead_keys:
+            del self._rpc_subscribers[key]
+            _LOGGER.info('Removed dead RPC subscriber: %s', key)
+
+        # Remove from available workers
+        self._available_workers = deque(w for w in self._available_workers if w != identity)
 
     def _mark_worker_available(self, identity: bytes) -> None:
         """Mark a worker as available for tasks."""
@@ -473,7 +506,10 @@ class ZmqBrokerServer:
             self._available_workers.append(identity)
 
     def _send_to_client(self, identity: bytes, msg: dict) -> None:
-        """Send a message to a specific client."""
+        """Send a message to a specific client.
+
+        :raises zmq.ZMQError: If the client is disconnected (ROUTER_MANDATORY).
+        """
         if not self._router:
             return
 

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -47,6 +47,7 @@ class ZmqBrokerServer:
         sockets_path: Path | str,
         encoder: Callable[[Any], str] | None = None,
         decoder: Callable[[str], Any] | None = None,
+        task_timeout: float = 10.0,
     ):
         """Initialize the broker server.
 
@@ -54,6 +55,7 @@ class ZmqBrokerServer:
         :param sockets_path: Path for IPC socket files
         :param encoder: Function to encode messages (default: yaml.dump)
         :param decoder: Function to decode messages (default: yaml.load)
+        :param task_timeout: Seconds before an unacked task is requeued (default: 10)
         """
         encoder = encoder if encoder is not None else YAML_ENCODER
         decoder = decoder if decoder is not None else YAML_DECODER
@@ -91,6 +93,10 @@ class ZmqBrokerServer:
         # Pending responses: correlation_id -> (client_identity, timestamp)
         self._pending_task_responses: dict[str, tuple[bytes, float]] = {}
         self._pending_rpc_responses: dict[str, tuple[bytes, float]] = {}
+
+        # Task timeout for redelivery: task_id -> dispatch_time
+        self._task_timeout = task_timeout
+        self._task_dispatch_times: dict[str, float] = {}
 
         # Server state
         self._running = False
@@ -221,6 +227,9 @@ class ZmqBrokerServer:
             self._handle_router_message()
             return True
 
+        # Requeue tasks stuck in processing beyond the timeout
+        self._requeue_timed_out_tasks()
+
         # Try to dispatch pending tasks to available workers
         self._dispatch_pending_tasks()
         return False
@@ -327,6 +336,7 @@ class ZmqBrokerServer:
         task_id = msg.get('task_id')
         if task_id:
             self._task_queue.ack(task_id)
+            self._task_dispatch_times.pop(task_id, None)
             _LOGGER.debug('Task acknowledged: %s', task_id)
 
         # Worker is available for more tasks
@@ -448,6 +458,26 @@ class ZmqBrokerServer:
             del self._rpc_subscribers[identifier]
             _LOGGER.info('RPC subscriber removed: %s', identifier)
 
+    def _requeue_timed_out_tasks(self) -> None:
+        """Requeue tasks that have been in processing beyond the timeout.
+
+        This handles the case where a worker received a task but crashed
+        before sending an ACK.
+        """
+        if not self._task_dispatch_times:
+            return
+
+        now = time.time()
+        timed_out = [
+            task_id for task_id, dispatch_time in self._task_dispatch_times.items()
+            if now - dispatch_time > self._task_timeout
+        ]
+
+        for task_id in timed_out:
+            self._task_dispatch_times.pop(task_id, None)
+            self._task_queue.nack(task_id, requeue=True)
+            _LOGGER.warning('Task %s timed out after %.1fs, requeued', task_id, self._task_timeout)
+
     def _dispatch_pending_tasks(self) -> None:
         """Dispatch pending tasks to available workers."""
         while self._available_workers and not self._task_queue.is_empty():
@@ -481,6 +511,7 @@ class ZmqBrokerServer:
                 self._task_queue.nack(task_id, requeue=True)
                 self._remove_dead_worker(worker_identity)
                 continue
+            self._task_dispatch_times[task_id] = time.time()
             _LOGGER.debug('Dispatched task %s to worker', task_id)
 
     def _remove_dead_worker(self, identity: bytes) -> None:

--- a/src/aiida/brokers/zmq/server.py
+++ b/src/aiida/brokers/zmq/server.py
@@ -187,10 +187,12 @@ class ZmqBrokerServer:
             self._monitor = None
 
         if self._router:
+            self._router.setsockopt(zmq.LINGER, 0)
             self._router.close()
             self._router = None
 
         if self._pub:
+            self._pub.setsockopt(zmq.LINGER, 0)
             self._pub.close()
             self._pub = None
 

--- a/src/aiida/brokers/zmq/service.py
+++ b/src/aiida/brokers/zmq/service.py
@@ -1,0 +1,305 @@
+"""ZMQ Broker Service - thin process wrapper for ZmqBrokerServer.
+
+This module provides process lifecycle management for the ZMQ broker server:
+- PID file management
+- Signal handling (SIGINT for cross-platform shutdown)
+- Status file updates
+- CLI entry point
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from .server import ZmqBrokerServer
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ZmqBrokerService:
+    """Process wrapper for ZmqBrokerServer.
+
+    Responsibilities:
+    - Instantiate and run ZmqBrokerServer
+    - Write PID file on start, remove on stop
+    - Handle SIGINT for cross-platform shutdown
+    - Write status info to file periodically
+
+    Directory structure:
+        {base_path}/
+        ├── storage/        # Task queue persistence (passed to server)
+        ├── logs/           # Log files
+        ├── broker.pid      # PID file
+        ├── broker.status   # Status JSON file
+        └── broker.sockets  # Path to temp directory containing sockets
+
+        {temp_dir}/         # Temp directory for sockets (short path for IPC)
+        ├── router.sock
+        └── pub.sock
+
+    Note: Unix domain sockets have a path length limit (~107 bytes), so we use
+    a temporary directory with a short path for the socket files.
+    """
+
+    def __init__(
+        self,
+        base_path: Path | str,
+        log_file: Path | str | None = None,
+    ):
+        """Initialize the broker service.
+
+        :param base_path: Base path for broker data
+        :param log_file: Path to log file (default: {base_path}/logs/broker.log)
+        """
+        self._base_path = Path(base_path)
+        self._storage_path = self._base_path / 'storage'
+        self._logs_path = self._base_path / 'logs'
+
+        # Sockets will be created in a temp directory (short path for IPC limit)
+        self._sockets_path: Path | None = None
+        self._sockets_file = self._base_path / 'broker.sockets'
+
+        # Ensure directories exist
+        self._logs_path.mkdir(parents=True, exist_ok=True)
+
+        # File paths
+        self._pid_file = self._base_path / 'broker.pid'
+        self._status_file = self._base_path / 'broker.status'
+        self._log_file = Path(log_file) if log_file else self._logs_path / 'broker.log'
+
+        # Server instance
+        self._server: ZmqBrokerServer | None = None
+        self._running = False
+
+        # Set up logging
+        self._setup_logging()
+
+    @property
+    def base_path(self) -> Path:
+        """Return the base path for broker data."""
+        return self._base_path
+
+    @property
+    def pid_file(self) -> Path:
+        """Return the PID file path."""
+        return self._pid_file
+
+    @property
+    def status_file(self) -> Path:
+        """Return the status file path."""
+        return self._status_file
+
+    @property
+    def log_file(self) -> Path:
+        """Return the log file path."""
+        return self._log_file
+
+    def _setup_logging(self) -> None:
+        """Set up file logging for the broker service."""
+        file_handler = logging.FileHandler(self._log_file)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+
+        # Add handler to relevant loggers
+        for logger_name in [__name__, 'aiida.brokers.zmq.server', 'aiida.brokers.zmq.queue']:
+            logger = logging.getLogger(logger_name)
+            logger.addHandler(file_handler)
+            logger.setLevel(logging.DEBUG)
+
+    def _setup_signal_handlers(self) -> None:
+        """Set up signal handlers for graceful shutdown.
+
+        Uses SIGINT which is available on all platforms (including Windows).
+        """
+        signal.signal(signal.SIGINT, self._handle_shutdown)
+        _LOGGER.debug('Signal handlers installed')
+
+    def _handle_shutdown(self, signum: int, frame: Any) -> None:
+        """Handle shutdown signal."""
+        _LOGGER.info('Received shutdown signal (%s)', signum)
+        self._running = False
+
+    def _write_pid_file(self) -> None:
+        """Write current PID to file."""
+        pid = os.getpid()
+        self._pid_file.write_text(str(pid))
+        _LOGGER.debug('Wrote PID file: %s (pid=%d)', self._pid_file, pid)
+
+    def _remove_pid_file(self) -> None:
+        """Remove PID file."""
+        if self._pid_file.exists():
+            self._pid_file.unlink()
+            _LOGGER.debug('Removed PID file: %s', self._pid_file)
+
+    def _write_status(self, status: dict) -> None:
+        """Write status info to file."""
+        status['timestamp'] = time.time()
+        status['pid'] = os.getpid()
+
+        # Write atomically
+        temp_file = self._status_file.with_suffix('.tmp')
+        temp_file.write_text(json.dumps(status, indent=2))
+        temp_file.rename(self._status_file)
+
+    def _remove_status_file(self) -> None:
+        """Remove status file."""
+        if self._status_file.exists():
+            self._status_file.unlink()
+            _LOGGER.debug('Removed status file: %s', self._status_file)
+
+    def _create_sockets_directory(self) -> Path:
+        """Create a temporary directory for socket files.
+
+        Unix domain sockets have a path length limit (~107 bytes on macOS, 108 on Linux).
+        We use a temporary directory to ensure the path is short enough.
+
+        :return: Path to the temporary socket directory
+        """
+        socket_dir = Path(tempfile.mkdtemp(prefix='aiida_zmq_'))
+        self._sockets_file.write_text(str(socket_dir))
+        _LOGGER.debug('Created socket directory: %s', socket_dir)
+        return socket_dir
+
+    def _remove_sockets_directory(self) -> None:
+        """Remove the temporary socket directory."""
+        if self._sockets_path and self._sockets_path.exists():
+            try:
+                shutil.rmtree(self._sockets_path)
+                _LOGGER.debug('Removed socket directory: %s', self._sockets_path)
+            except OSError as e:
+                _LOGGER.warning('Failed to remove socket directory: %s', e)
+
+        if self._sockets_file.exists():
+            self._sockets_file.unlink()
+            _LOGGER.debug('Removed sockets file: %s', self._sockets_file)
+
+    def start(self) -> None:
+        """Start the broker service.
+
+        Creates the server and writes PID file.
+        """
+        if self._running:
+            return
+
+        _LOGGER.info('Starting ZMQ Broker Service')
+        _LOGGER.info('Base path: %s', self._base_path)
+        _LOGGER.info('Log file: %s', self._log_file)
+
+        # Create temp directory for sockets (short path for IPC limit)
+        self._sockets_path = self._create_sockets_directory()
+        _LOGGER.info('Sockets path: %s', self._sockets_path)
+
+        # Create server
+        self._server = ZmqBrokerServer(
+            storage_path=self._storage_path,
+            sockets_path=self._sockets_path,
+        )
+
+        # Write PID file
+        self._write_pid_file()
+
+        # Set up signal handlers
+        self._setup_signal_handlers()
+
+        # Start server
+        self._server.start()
+        self._running = True
+
+        # Write initial status
+        self._write_status(self._server.get_status())
+
+        _LOGGER.info('ZMQ Broker Service started')
+
+    def stop(self) -> None:
+        """Stop the broker service.
+
+        Stops the server and removes PID file.
+        """
+        if not self._running:
+            return
+
+        _LOGGER.info('Stopping ZMQ Broker Service')
+        self._running = False
+
+        if self._server:
+            self._server.stop()
+            self._server = None
+
+        self._remove_pid_file()
+        self._remove_status_file()
+        self._remove_sockets_directory()
+
+        _LOGGER.info('ZMQ Broker Service stopped')
+
+    def run_forever(self, poll_timeout: int = 1000, status_interval: float = 5.0) -> None:
+        """Run the broker service until stopped.
+
+        Blocks until stop() is called or SIGINT received.
+
+        :param poll_timeout: Polling timeout in milliseconds
+        :param status_interval: Interval for status file updates in seconds
+        """
+        self.start()
+
+        last_status_time = time.time()
+
+        try:
+            while self._running and self._server:
+                self._server.run_once(poll_timeout)
+
+                # Update status file periodically
+                now = time.time()
+                if now - last_status_time >= status_interval:
+                    self._write_status(self._server.get_status())
+                    last_status_time = now
+
+        except KeyboardInterrupt:
+            _LOGGER.info('Interrupted')
+        finally:
+            self.stop()
+
+
+def run_broker_service(
+    base_path: str | Path,
+    log_file: str | Path | None = None,
+) -> None:
+    """Run the broker service as a standalone process.
+
+    :param base_path: Base path for broker data
+    :param log_file: Path to log file (default: {base_path}/logs/broker.log)
+    """
+    service = ZmqBrokerService(
+        base_path=base_path,
+        log_file=log_file,
+    )
+    service.run_forever()
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='ZMQ Broker Service')
+    parser.add_argument('--base-path', '-b', required=True, help='Base directory for broker data')
+    parser.add_argument('--log-file', '-l', help='Log file path (default: {base_path}/logs/broker.log)')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Enable debug logging to console')
+
+    args = parser.parse_args()
+
+    # Set up console logging
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    )
+
+    run_broker_service(
+        base_path=args.base_path,
+        log_file=args.log_file,
+    )

--- a/src/aiida/brokers/zmq/service.py
+++ b/src/aiida/brokers/zmq/service.py
@@ -53,18 +53,15 @@ class ZmqBrokerService:
         self,
         base_path: Path | str,
         log_file: Path | str | None = None,
-        task_timeout: float = 10.0,
     ):
         """Initialize the broker service.
 
         :param base_path: Base path for broker data
         :param log_file: Path to log file (default: {base_path}/logs/broker.log)
-        :param task_timeout: Seconds before an unacked task is requeued (default: 10)
         """
         self._base_path = Path(base_path)
         self._storage_path = self._base_path / 'storage'
         self._logs_path = self._base_path / 'logs'
-        self._task_timeout = task_timeout
 
         # Sockets will be created in a temp directory (short path for IPC limit)
         self._sockets_path: Path | None = None
@@ -204,7 +201,6 @@ class ZmqBrokerService:
         self._server = ZmqBrokerServer(
             storage_path=self._storage_path,
             sockets_path=self._sockets_path,
-            task_timeout=self._task_timeout,
         )
 
         # Write PID file
@@ -274,18 +270,15 @@ class ZmqBrokerService:
 def run_broker_service(
     base_path: str | Path,
     log_file: str | Path | None = None,
-    task_timeout: float = 10.0,
 ) -> None:
     """Run the broker service as a standalone process.
 
     :param base_path: Base path for broker data
     :param log_file: Path to log file (default: {base_path}/logs/broker.log)
-    :param task_timeout: Seconds before an unacked task is requeued (default: 10)
     """
     service = ZmqBrokerService(
         base_path=base_path,
         log_file=log_file,
-        task_timeout=task_timeout,
     )
     service.run_forever()
 
@@ -296,8 +289,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ZMQ Broker Service')
     parser.add_argument('--base-path', '-b', required=True, help='Base directory for broker data')
     parser.add_argument('--log-file', '-l', help='Log file path (default: {base_path}/logs/broker.log)')
-    parser.add_argument('--task-timeout', '-t', type=float, default=10.0,
-                        help='Seconds before an unacked task is requeued (default: 10)')
     parser.add_argument('--verbose', '-v', action='store_true', help='Enable debug logging to console')
 
     args = parser.parse_args()
@@ -311,5 +302,4 @@ if __name__ == '__main__':
     run_broker_service(
         base_path=args.base_path,
         log_file=args.log_file,
-        task_timeout=args.task_timeout,
     )

--- a/src/aiida/brokers/zmq/service.py
+++ b/src/aiida/brokers/zmq/service.py
@@ -53,15 +53,18 @@ class ZmqBrokerService:
         self,
         base_path: Path | str,
         log_file: Path | str | None = None,
+        task_timeout: float = 10.0,
     ):
         """Initialize the broker service.
 
         :param base_path: Base path for broker data
         :param log_file: Path to log file (default: {base_path}/logs/broker.log)
+        :param task_timeout: Seconds before an unacked task is requeued (default: 10)
         """
         self._base_path = Path(base_path)
         self._storage_path = self._base_path / 'storage'
         self._logs_path = self._base_path / 'logs'
+        self._task_timeout = task_timeout
 
         # Sockets will be created in a temp directory (short path for IPC limit)
         self._sockets_path: Path | None = None
@@ -201,6 +204,7 @@ class ZmqBrokerService:
         self._server = ZmqBrokerServer(
             storage_path=self._storage_path,
             sockets_path=self._sockets_path,
+            task_timeout=self._task_timeout,
         )
 
         # Write PID file
@@ -270,15 +274,18 @@ class ZmqBrokerService:
 def run_broker_service(
     base_path: str | Path,
     log_file: str | Path | None = None,
+    task_timeout: float = 10.0,
 ) -> None:
     """Run the broker service as a standalone process.
 
     :param base_path: Base path for broker data
     :param log_file: Path to log file (default: {base_path}/logs/broker.log)
+    :param task_timeout: Seconds before an unacked task is requeued (default: 10)
     """
     service = ZmqBrokerService(
         base_path=base_path,
         log_file=log_file,
+        task_timeout=task_timeout,
     )
     service.run_forever()
 
@@ -289,6 +296,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ZMQ Broker Service')
     parser.add_argument('--base-path', '-b', required=True, help='Base directory for broker data')
     parser.add_argument('--log-file', '-l', help='Log file path (default: {base_path}/logs/broker.log)')
+    parser.add_argument('--task-timeout', '-t', type=float, default=10.0,
+                        help='Seconds before an unacked task is requeued (default: 10)')
     parser.add_argument('--verbose', '-v', action='store_true', help='Enable debug logging to console')
 
     args = parser.parse_args()
@@ -302,4 +311,5 @@ if __name__ == '__main__':
     run_broker_service(
         base_path=args.base_path,
         log_file=args.log_file,
+        task_timeout=args.task_timeout,
     )

--- a/src/aiida/cmdline/commands/__init__.py
+++ b/src/aiida/cmdline/commands/__init__.py
@@ -14,6 +14,7 @@ The commands need to be imported here for them to be registered with the top-lev
 
 from aiida.cmdline.commands import (
     cmd_archive,
+    cmd_broker,
     cmd_calcjob,
     cmd_code,
     cmd_computer,

--- a/src/aiida/cmdline/commands/cmd_broker.py
+++ b/src/aiida/cmdline/commands/cmd_broker.py
@@ -1,0 +1,133 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""`verdi broker` commands for managing the message broker service."""
+
+from __future__ import annotations
+
+import click
+
+from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.utils import echo
+from aiida.cmdline.utils.decorators import with_broker
+
+
+@verdi.group('broker')
+def verdi_broker():
+    """Manage the message broker service.
+
+    The message broker is required for daemon operation and process control.
+    RabbitMQ is an external service managed by your system's service manager.
+    ZMQ is a built-in broker service that is managed by these commands.
+    """
+
+
+def _check_broker_controllable(broker):
+    """Check if the broker supports service control commands.
+
+    :param broker: The broker instance
+    :raises click.ClickException: If the broker does not support service control
+    """
+    if not hasattr(broker, 'controller'):
+        broker_name = type(broker).__name__
+        raise click.ClickException(
+            f'Broker `{broker_name}` does not support this command.\n'
+            'RabbitMQ is an external service - manage it using your system service manager '
+            '(e.g., `systemctl start rabbitmq-server` or `brew services start rabbitmq`).'
+        )
+
+
+@verdi_broker.command('start')
+@with_broker
+def broker_start(broker):
+    """Start the broker service.
+
+    This command is only available for broker backends that run as a managed service
+    (e.g., ZMQ). For RabbitMQ, use your system's service manager.
+    """
+    _check_broker_controllable(broker)
+
+    if broker.controller.is_running():
+        echo.echo_report('Broker service is already running.')
+        return
+
+    try:
+        broker.controller.start()
+        echo.echo_success('Broker service started.')
+    except Exception as exc:
+        raise click.ClickException(f'Failed to start broker service: {exc}') from exc
+
+
+@verdi_broker.command('stop')
+@with_broker
+def broker_stop(broker):
+    """Stop the broker service.
+
+    This command is only available for broker backends that run as a managed service
+    (e.g., ZMQ). For RabbitMQ, use your system's service manager.
+    """
+    _check_broker_controllable(broker)
+
+    if not broker.controller.is_running():
+        echo.echo_report('Broker service is not running.')
+        return
+
+    try:
+        broker.controller.stop()
+        echo.echo_success('Broker service stopped.')
+    except Exception as exc:
+        raise click.ClickException(f'Failed to stop broker service: {exc}') from exc
+
+
+@verdi_broker.command('restart')
+@with_broker
+def broker_restart(broker):
+    """Restart the broker service.
+
+    This command is only available for broker backends that run as a managed service
+    (e.g., ZMQ). For RabbitMQ, use your system's service manager.
+    """
+    _check_broker_controllable(broker)
+
+    try:
+        if broker.controller.is_running():
+            broker.controller.stop()
+        broker.controller.start()
+        echo.echo_success('Broker service restarted.')
+    except Exception as exc:
+        raise click.ClickException(f'Failed to restart broker service: {exc}') from exc
+
+
+@verdi_broker.command('status')
+@with_broker
+def broker_status(broker):
+    """Show the broker service status."""
+    echo.echo_report(f'Broker: {broker}')
+
+    if hasattr(broker, 'controller'):
+        if broker.controller.is_running():
+            status = broker.controller.get_status()
+            echo.echo_success('Broker service is running.')
+            if status:
+                echo.echo(f'  PID: {status.get("pid", "unknown")}')
+                echo.echo(f'  Pending tasks: {status.get("pending_tasks", 0)}')
+                echo.echo(f'  Processing tasks: {status.get("processing_tasks", 0)}')
+        else:
+            echo.echo_warning('Broker service is not running.')
+            echo.echo_report('Start it with `verdi broker start`.')
+    else:
+        # RabbitMQ or other external broker
+        echo.echo_report('This broker is an external service.')
+        echo.echo_report('Check its status using your system service manager.')
+
+        # Try to verify connectivity
+        try:
+            broker.get_communicator()
+            echo.echo_success('Connection to broker successful.')
+        except Exception as exc:
+            echo.echo_warning(f'Cannot connect to broker: {exc}')

--- a/src/aiida/cmdline/params/options/commands/setup.py
+++ b/src/aiida/cmdline/params/options/commands/setup.py
@@ -342,11 +342,20 @@ SETUP_DATABASE_PASSWORD = QUICKSETUP_DATABASE_PASSWORD.clone(
 
 SETUP_USE_RABBITMQ = options.OverridableOption(
     '--use-rabbitmq/--no-use-rabbitmq',
-    prompt='Use RabbitMQ?',
     is_flag=True,
-    default=True,
+    default=None,
+    hidden=True,
+    help='Deprecated: use --broker instead. --no-use-rabbitmq is equivalent to --broker none.',
+)
+
+SETUP_BROKER_BACKEND = options.OverridableOption(
+    '--broker',
+    prompt='Message broker',
+    type=click.Choice(['rabbitmq', 'zmq', 'none']),
+    default='rabbitmq',
     cls=options.interactive.InteractiveOption,
-    help='Whether to configure the RabbitMQ broker. Required to enable the daemon and submitting processes.',
+    help='Message broker backend for process control. Use "rabbitmq" for RabbitMQ (requires external server), '
+    '"zmq" for ZeroMQ (built-in, no external dependencies), or "none" to disable (limited functionality).',
 )
 
 SETUP_BROKER_PROTOCOL = QUICKSETUP_BROKER_PROTOCOL.clone(

--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -36,6 +36,15 @@ async def shutdown_worker(runner: Runner) -> None:
 
     runner.close()
 
+    # Reset the profile so the communicator sends unsubscribe messages to
+    # the broker server before disconnecting, and database connections are
+    # released.  Without this, the server keeps routing tasks/RPCs to our
+    # (now-dead) identity.
+    try:
+        get_manager().reset_profile()
+    except Exception:
+        pass
+
     LOGGER.info('Daemon worker stopped')
 
 

--- a/src/aiida/engine/daemon/worker.py
+++ b/src/aiida/engine/daemon/worker.py
@@ -34,16 +34,12 @@ async def shutdown_worker(runner: Runner) -> None:
 
     await asyncio.gather(*tasks, return_exceptions=True)
 
-    runner.close()
-
     # Reset the profile so the communicator sends unsubscribe messages to
     # the broker server before disconnecting, and database connections are
     # released.  Without this, the server keeps routing tasks/RPCs to our
     # (now-dead) identity.
-    try:
-        get_manager().reset_profile()
-    except Exception:
-        pass
+    #get_manager().reset_profile()
+    runner.close()
 
     LOGGER.info('Daemon worker stopped')
 
@@ -83,6 +79,7 @@ def start_daemon_worker(foreground: bool = False, profile_name: Union[str, None]
         runner.start()
     except SystemError as exception:
         LOGGER.info('Received a SystemError: %s', exception)
+        #get_manager().reset_profile()
         runner.close()
 
     LOGGER.info('Daemon worker started')

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -237,6 +237,11 @@ def _perform_actions(
 
     _resolve_futures(futures, infinitive, present, timeout)
 
+    # End the current read transaction so that subsequent attribute reads see
+    # the state committed by the daemon.  Without this, SQLite's transaction
+    # snapshot isolation can cause stale reads after the RPC round-trip.
+    get_manager().get_profile_storage().get_session().commit()
+
 
 def _resolve_futures(
     futures: dict[concurrent.futures.Future, ProcessNode],

--- a/src/aiida/engine/processes/control.py
+++ b/src/aiida/engine/processes/control.py
@@ -240,7 +240,31 @@ def _perform_actions(
     # End the current read transaction so that subsequent attribute reads see
     # the state committed by the daemon.  Without this, SQLite's transaction
     # snapshot isolation can cause stale reads after the RPC round-trip.
-    get_manager().get_profile_storage().get_session().commit()
+    session = get_manager().get_profile_storage().get_session()
+    LOGGER.report(f'DEBUG: session.is_active={session.is_active}, in_transaction={session.in_transaction()}, dirty={bool(session.dirty)}, new={bool(session.new)}')
+    session.commit()
+    LOGGER.report('DEBUG: session.commit() completed')
+
+    # Debug: check what raw sqlite3 shows vs SQLAlchemy
+    import json
+    import sqlite3
+    storage = get_manager().get_profile_storage()
+    db_path = getattr(storage, 'filepath_database', None)
+    LOGGER.report(f'DEBUG: db_path={db_path}, storage_class={type(storage).__name__}')
+    for process in processes:
+        pk = process.pk
+        # Completely independent sqlite3 connection (bypasses SQLAlchemy entirely)
+        if db_path:
+            conn = sqlite3.connect(str(db_path))
+            row = conn.execute(f'SELECT attributes FROM db_dbnode WHERE id = {pk}').fetchone()
+            conn.close()
+            if row:
+                raw_attrs = json.loads(row[0]) if isinstance(row[0], str) else row[0]
+                LOGGER.report(f'DEBUG: Process<{pk}> direct sqlite3: paused={raw_attrs.get("paused", "NOT_SET")}')
+        # SQLAlchemy ORM read after commit
+        session.expire(process.backend_entity.bare_model)
+        orm_attrs = process.backend_entity.bare_model.attributes
+        LOGGER.report(f'DEBUG: Process<{pk}> ORM after commit+expire: paused={orm_attrs.get("paused", "NOT_SET")}')
 
 
 def _resolve_futures(

--- a/src/aiida/engine/processes/process.py
+++ b/src/aiida/engine/processes/process.py
@@ -559,8 +559,12 @@ class Process(PlumpyProcess):
     @override
     def on_playing(self) -> None:
         """The Process was unpaused so remove the paused attribute on the process node"""
+        import logging
+        _dbg = logging.getLogger('aiida.process_control')
+        _dbg.report(f'DEBUG DAEMON: on_playing() called for Process<{self.node.pk}>')
         super().on_playing()
         self.node.unpause()
+        _dbg.report(f'DEBUG DAEMON: node.unpause() completed for Process<{self.node.pk}>')
 
     @override
     def on_output_emitting(self, output_port: str, value: Any) -> None:

--- a/src/aiida/manage/manager.py
+++ b/src/aiida/manage/manager.py
@@ -305,6 +305,8 @@ class Manager:
             # Backwards compatibility. Before adding broker entry points, profiles used to define ``rabbitmq``.
             if entry_point == 'rabbitmq':
                 entry_point = 'core.rabbitmq'
+            elif entry_point == 'zmq':
+                entry_point = 'core.zmq'
 
             broker_cls = BrokerFactory(entry_point)
             self._broker = broker_cls(self._profile)

--- a/src/aiida/tools/pytest_fixtures/configuration.py
+++ b/src/aiida/tools/pytest_fixtures/configuration.py
@@ -140,6 +140,7 @@ def aiida_profile_factory():
             email=email,
             is_test_profile=True,
         )
+        profile.set_option('warnings.development_version', False)
         config.set_default_profile(profile.name)
         config.store()
 

--- a/tests/brokers/test_zmq.py
+++ b/tests/brokers/test_zmq.py
@@ -1,0 +1,343 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the `aiida.brokers.zmq` module."""
+
+import pytest
+
+from aiida.brokers.zmq import ZmqBrokerController, ZmqCommunicator, get_zmq_config
+from aiida.brokers.zmq.queue import PersistentQueue
+from aiida.brokers.zmq.server import ZmqBrokerServer
+from aiida.brokers.zmq.service import ZmqBrokerService
+
+
+class TestZmqDefaults:
+    """Tests for the ZMQ defaults module."""
+
+    def test_get_zmq_config(self):
+        """Test that get_zmq_config returns an empty dict."""
+        config = get_zmq_config()
+        assert config == {}
+
+
+class TestZmqBrokerController:
+    """Tests for the ZmqBrokerController."""
+
+    def test_init(self, tmp_path):
+        """Test controller initialization."""
+        controller = ZmqBrokerController(tmp_path)
+        assert controller.base_path == tmp_path
+        assert controller.pid_file == tmp_path / 'broker.pid'
+        assert controller.status_file == tmp_path / 'broker.status'
+
+    def test_is_running_no_pid_file(self, tmp_path):
+        """Test is_running returns False when no PID file exists."""
+        controller = ZmqBrokerController(tmp_path)
+        assert not controller.is_running()
+
+    def test_get_pid_no_file(self, tmp_path):
+        """Test get_pid returns None when no PID file exists."""
+        controller = ZmqBrokerController(tmp_path)
+        assert controller.get_pid() is None
+
+    def test_get_status_no_file(self, tmp_path):
+        """Test get_status returns None when no status file exists."""
+        controller = ZmqBrokerController(tmp_path)
+        assert controller.get_status() is None
+
+    def test_endpoints_no_sockets_file(self, tmp_path):
+        """Test endpoints return None when sockets file doesn't exist."""
+        controller = ZmqBrokerController(tmp_path)
+        assert controller.router_endpoint is None
+        assert controller.pub_endpoint is None
+
+    def test_start_stop_cycle(self, tmp_path):
+        """Test starting and stopping the broker service."""
+        controller = ZmqBrokerController(tmp_path)
+
+        # Start the broker
+        assert controller.start(wait=True, timeout=10.0)
+        assert controller.is_running()
+        assert controller.get_pid() is not None
+        assert controller.router_endpoint is not None
+        assert controller.pub_endpoint is not None
+
+        # Stop the broker
+        assert controller.stop(timeout=5.0)
+        assert not controller.is_running()
+
+    def test_start_already_running(self, tmp_path):
+        """Test starting when already running returns True."""
+        controller = ZmqBrokerController(tmp_path)
+
+        try:
+            controller.start(wait=True, timeout=10.0)
+            # Starting again should just return True
+            assert controller.start(wait=True, timeout=10.0)
+        finally:
+            controller.stop()
+
+    def test_stop_not_running(self, tmp_path):
+        """Test stopping when not running returns True."""
+        controller = ZmqBrokerController(tmp_path)
+        assert controller.stop()
+
+    def test_restart(self, tmp_path):
+        """Test restarting the broker service."""
+        controller = ZmqBrokerController(tmp_path)
+
+        try:
+            controller.start(wait=True, timeout=10.0)
+            old_pid = controller.get_pid()
+
+            assert controller.restart(timeout=5.0)
+            assert controller.is_running()
+
+            # PID should be different after restart
+            new_pid = controller.get_pid()
+            assert new_pid != old_pid
+        finally:
+            controller.stop()
+
+
+class TestZmqBrokerServer:
+    """Tests for the ZmqBrokerServer."""
+
+    def test_init(self, tmp_path):
+        """Test server initialization."""
+        storage_path = tmp_path / 'storage'
+        sockets_path = tmp_path / 'sockets'
+
+        server = ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+        assert server.storage_path == storage_path
+        assert server.sockets_path == sockets_path
+
+    def test_start_stop(self):
+        """Test starting and stopping the server."""
+        import tempfile
+
+        # Use short temp directory to avoid socket path length limit
+        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+            from pathlib import Path
+
+            tmp_path = Path(tmp)
+            storage_path = tmp_path / 's'
+            sockets_path = tmp_path / 'k'
+
+            server = ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+            server.start()
+
+            try:
+                status = server.get_status()
+                assert 'pending_tasks' in status
+                assert 'processing_tasks' in status
+            finally:
+                server.stop()
+
+    def test_get_status(self):
+        """Test getting server status."""
+        import tempfile
+
+        # Use short temp directory to avoid socket path length limit
+        with tempfile.TemporaryDirectory(prefix='zmq') as tmp:
+            from pathlib import Path
+
+            tmp_path = Path(tmp)
+            storage_path = tmp_path / 's'
+            sockets_path = tmp_path / 'k'
+
+            server = ZmqBrokerServer(storage_path=storage_path, sockets_path=sockets_path)
+            server.start()
+
+            try:
+                status = server.get_status()
+                assert status['pending_tasks'] == 0
+                assert status['processing_tasks'] == 0
+            finally:
+                server.stop()
+
+
+class TestZmqBrokerService:
+    """Tests for the ZmqBrokerService."""
+
+    def test_init(self, tmp_path):
+        """Test service initialization."""
+        service = ZmqBrokerService(base_path=tmp_path)
+        assert service.base_path == tmp_path
+        assert service.pid_file == tmp_path / 'broker.pid'
+        assert service.status_file == tmp_path / 'broker.status'
+
+    def test_start_stop(self, tmp_path):
+        """Test starting and stopping the service."""
+        service = ZmqBrokerService(base_path=tmp_path)
+        service.start()
+
+        try:
+            assert service.pid_file.exists()
+            assert service.status_file.exists()
+        finally:
+            service.stop()
+
+        assert not service.pid_file.exists()
+        assert not service.status_file.exists()
+
+
+class TestPersistentQueue:
+    """Tests for the PersistentQueue."""
+
+    def test_init(self, tmp_path):
+        """Test queue initialization."""
+        queue = PersistentQueue(tmp_path)
+        assert queue._storage_path == tmp_path
+
+    def test_push_pop(self, tmp_path):
+        """Test pushing and popping tasks."""
+        queue = PersistentQueue(tmp_path)
+
+        # Push a task
+        task_id = 'task-001'
+        queue.push(task_id, {'type': 'test', 'data': 'hello'})
+
+        # Pop the task
+        popped_id, task_data = queue.pop()
+        assert popped_id == task_id
+        assert task_data['type'] == 'test'
+        assert task_data['data'] == 'hello'
+
+    def test_pop_empty(self, tmp_path):
+        """Test popping from empty queue."""
+        queue = PersistentQueue(tmp_path)
+        result = queue.pop()
+        assert result is None
+
+    def test_ack_task(self, tmp_path):
+        """Test acknowledging a task."""
+        queue = PersistentQueue(tmp_path)
+
+        task_id = 'task-002'
+        queue.push(task_id, {'type': 'test'})
+        queue.pop()
+        result = queue.ack(task_id)
+
+        assert result is True
+        # Task should no longer be in queue
+        assert queue.pop() is None
+
+    def test_nack_task(self, tmp_path):
+        """Test negative acknowledgment (requeue)."""
+        queue = PersistentQueue(tmp_path)
+
+        task_id = 'task-003'
+        queue.push(task_id, {'type': 'test'})
+        queue.pop()
+        result = queue.nack(task_id, requeue=True)
+
+        assert result is True
+        # Task should be requeued
+        popped_id, _ = queue.pop()
+        assert popped_id == task_id
+
+    def test_get_all_pending(self, tmp_path):
+        """Test getting all pending tasks."""
+        queue = PersistentQueue(tmp_path)
+
+        task_id1 = 'task-004'
+        task_id2 = 'task-005'
+        queue.push(task_id1, {'type': 'test1'})
+        queue.push(task_id2, {'type': 'test2'})
+
+        pending = queue.get_all_pending()
+        assert len(pending) == 2
+
+        task_ids = [t[0] for t in pending]
+        assert task_id1 in task_ids
+        assert task_id2 in task_ids
+
+
+class TestZmqCommunicator:
+    """Tests for the ZmqCommunicator."""
+
+    def test_init(self, tmp_path):
+        """Test communicator initialization."""
+        controller = ZmqBrokerController(tmp_path)
+
+        try:
+            controller.start(wait=True, timeout=10.0)
+
+            communicator = ZmqCommunicator(
+                router_endpoint=controller.router_endpoint,
+                pub_endpoint=controller.pub_endpoint,
+            )
+            communicator.start()
+
+            try:
+                assert communicator.is_closed() is False
+            finally:
+                communicator.close()
+
+            assert communicator.is_closed() is True
+        finally:
+            controller.stop()
+
+    def test_context_manager(self, tmp_path):
+        """Test communicator as context manager."""
+        controller = ZmqBrokerController(tmp_path)
+
+        try:
+            controller.start(wait=True, timeout=10.0)
+
+            with ZmqCommunicator(
+                router_endpoint=controller.router_endpoint,
+                pub_endpoint=controller.pub_endpoint,
+            ) as communicator:
+                # Context manager calls start() automatically
+                assert communicator.is_closed() is False
+
+            assert communicator.is_closed() is True
+        finally:
+            controller.stop()
+
+
+class TestZmqBrokerIntegration:
+    """Integration tests for the ZMQ broker with AiiDA."""
+
+    @pytest.fixture
+    def zmq_broker(self, tmp_path, monkeypatch):
+        """Create a ZMQ broker for testing."""
+
+        # Create a mock profile-like structure
+        broker_dir = tmp_path / 'broker' / 'test-uuid'
+        broker_dir.mkdir(parents=True)
+
+        controller = ZmqBrokerController(broker_dir)
+        controller.start(wait=True, timeout=10.0)
+
+        yield controller
+
+        controller.stop()
+
+    def test_broker_lifecycle(self, zmq_broker):
+        """Test the broker lifecycle."""
+        assert zmq_broker.is_running()
+
+        status = zmq_broker.get_status()
+        assert status is not None
+        assert 'pid' in status
+
+    def test_communicator_connection(self, zmq_broker):
+        """Test connecting a communicator to the broker."""
+        communicator = ZmqCommunicator(
+            router_endpoint=zmq_broker.router_endpoint,
+            pub_endpoint=zmq_broker.pub_endpoint,
+        )
+        communicator.start()
+
+        try:
+            assert not communicator.is_closed()
+        finally:
+            communicator.close()

--- a/tests/brokers/test_zmq.py
+++ b/tests/brokers/test_zmq.py
@@ -10,7 +10,7 @@
 
 import pytest
 
-from aiida.brokers.zmq import ZmqBrokerController, ZmqCommunicator, get_zmq_config
+from aiida.brokers.zmq import ZmqBrokerManagementClient, ZmqCommunicator, get_zmq_config
 from aiida.brokers.zmq.queue import PersistentQueue
 from aiida.brokers.zmq.server import ZmqBrokerServer
 from aiida.brokers.zmq.service import ZmqBrokerService
@@ -25,40 +25,40 @@ class TestZmqDefaults:
         assert config == {}
 
 
-class TestZmqBrokerController:
-    """Tests for the ZmqBrokerController."""
+class TestZmqBrokerManagementClient:
+    """Tests for the ZmqBrokerManagementClient."""
 
     def test_init(self, tmp_path):
         """Test controller initialization."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
         assert controller.base_path == tmp_path
         assert controller.pid_file == tmp_path / 'broker.pid'
         assert controller.status_file == tmp_path / 'broker.status'
 
     def test_is_running_no_pid_file(self, tmp_path):
         """Test is_running returns False when no PID file exists."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
         assert not controller.is_running()
 
     def test_get_pid_no_file(self, tmp_path):
         """Test get_pid returns None when no PID file exists."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
         assert controller.get_pid() is None
 
     def test_get_status_no_file(self, tmp_path):
         """Test get_status returns None when no status file exists."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
         assert controller.get_status() is None
 
     def test_endpoints_no_sockets_file(self, tmp_path):
         """Test endpoints return None when sockets file doesn't exist."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
         assert controller.router_endpoint is None
         assert controller.pub_endpoint is None
 
     def test_start_stop_cycle(self, tmp_path):
         """Test starting and stopping the broker service."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
 
         # Start the broker
         assert controller.start(wait=True, timeout=10.0)
@@ -73,7 +73,7 @@ class TestZmqBrokerController:
 
     def test_start_already_running(self, tmp_path):
         """Test starting when already running returns True."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
 
         try:
             controller.start(wait=True, timeout=10.0)
@@ -84,12 +84,12 @@ class TestZmqBrokerController:
 
     def test_stop_not_running(self, tmp_path):
         """Test stopping when not running returns True."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
         assert controller.stop()
 
     def test_restart(self, tmp_path):
         """Test restarting the broker service."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
 
         try:
             controller.start(wait=True, timeout=10.0)
@@ -264,7 +264,7 @@ class TestZmqCommunicator:
 
     def test_init(self, tmp_path):
         """Test communicator initialization."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
 
         try:
             controller.start(wait=True, timeout=10.0)
@@ -286,7 +286,7 @@ class TestZmqCommunicator:
 
     def test_context_manager(self, tmp_path):
         """Test communicator as context manager."""
-        controller = ZmqBrokerController(tmp_path)
+        controller = ZmqBrokerManagementClient(tmp_path)
 
         try:
             controller.start(wait=True, timeout=10.0)
@@ -314,7 +314,7 @@ class TestZmqBrokerIntegration:
         broker_dir = tmp_path / 'broker' / 'test-uuid'
         broker_dir.mkdir(parents=True)
 
-        controller = ZmqBrokerController(broker_dir)
+        controller = ZmqBrokerManagementClient(broker_dir)
         controller.start(wait=True, timeout=10.0)
 
         yield controller

--- a/tests/calculations/arithmetic/test_add.py
+++ b/tests/calculations/arithmetic/test_add.py
@@ -15,7 +15,7 @@ from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from aiida.common import datastructures
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_add_default(fixture_sandbox, aiida_localhost, generate_calc_job):
     """Test a default `ArithmeticAddCalculation`."""
     inputs = {
@@ -46,7 +46,7 @@ def test_add_default(fixture_sandbox, aiida_localhost, generate_calc_job):
         assert input_written == f"echo $(({inputs['x'].value} + {inputs['y'].value}))\n"
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_add_custom_filenames(fixture_sandbox, aiida_localhost, generate_calc_job):
     """Test an `ArithmeticAddCalculation` with non-default input and output filenames."""
     input_filename = 'custom.in'
@@ -71,7 +71,7 @@ def test_add_custom_filenames(fixture_sandbox, aiida_localhost, generate_calc_jo
     assert calc_info.retrieve_list == [output_filename]
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_sleep(fixture_sandbox, aiida_localhost, generate_calc_job):
     """Test the ``metadata.options.sleep`` input."""
     sleep = 5

--- a/tests/calculations/test_stash.py
+++ b/tests/calculations/test_stash.py
@@ -23,7 +23,7 @@ from aiida.common.datastructures import StashMode, UnstashTargetMode
 from aiida.plugins import CalculationFactory
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.parametrize(
     'operation_type,entry_point_name',
     [
@@ -215,7 +215,7 @@ def test_code_vs_stash_mode_conflict(stash_mode, fixture_sandbox, aiida_localhos
             generate_calc_job(fixture_sandbox, 'core.unstash', unstash_input)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.parametrize('unstash_target_mode', [UnstashTargetMode.NewRemoteData, UnstashTargetMode.OriginalPlace])
 def test_submit_custom_code(fixture_sandbox, aiida_localhost, generate_calc_job, tmp_path, unstash_target_mode):
     """Test the full functionality of the `StashCalculation` and `UnstashCalculation` with a custom code submission."""
@@ -369,7 +369,7 @@ done
 
 
 @pytest.mark.usefixtures('aiida_profile_clean')
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.parametrize(
     'unstash_target_mode', [UnstashTargetMode.OriginalPlace.value, UnstashTargetMode.NewRemoteData.value]
 )

--- a/tests/calculations/test_templatereplacer.py
+++ b/tests/calculations/test_templatereplacer.py
@@ -16,7 +16,7 @@ from aiida import orm
 from aiida.common import datastructures
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_base_template(fixture_sandbox, aiida_localhost, generate_calc_job):
     """Test a base template that emulates the arithmetic add."""
     entry_point_name = 'core.templatereplacer'
@@ -57,7 +57,7 @@ def test_base_template(fixture_sandbox, aiida_localhost, generate_calc_job):
         assert input_written == f"echo $(({inputs['parameters']['x']} + {inputs['parameters']['y']}))"
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_file_usage(fixture_sandbox, aiida_localhost, generate_calc_job):
     """Test a base template that uses two files."""
     file1_node = orm.SinglefileData(io.BytesIO(b'Content of file 1'))

--- a/tests/calculations/test_transfer.py
+++ b/tests/calculations/test_transfer.py
@@ -16,7 +16,7 @@ from aiida import orm
 from aiida.common import datastructures
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_get_transfer(fixture_sandbox, aiida_localhost, generate_calc_job, tmp_path):
     """Test a default `TransferCalculation`."""
     file1 = tmp_path / 'file1.txt'
@@ -64,7 +64,7 @@ def test_get_transfer(fixture_sandbox, aiida_localhost, generate_calc_job, tmp_p
     assert sorted(calc_info.retrieve_list) == sorted(retrieve_list)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_put_transfer(fixture_sandbox, aiida_localhost, generate_calc_job, tmp_path):
     """Test a default `TransferCalculation`."""
     file1 = tmp_path / 'file1.txt'
@@ -197,7 +197,7 @@ def test_validate_transfer_inputs(aiida_localhost, tmp_path):
     assert result == expected
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_integration_transfer(aiida_localhost, tmp_path):
     """Test a default `TransferCalculation`."""
     from aiida.calculations.transfer import TransferCalculation

--- a/tests/cmdline/commands/test_daemon.py
+++ b/tests/cmdline/commands/test_daemon.py
@@ -17,7 +17,7 @@ from aiida import get_profile
 from aiida.cmdline.commands import cmd_daemon
 from aiida.engine.daemon.client import DaemonClient
 
-pytestmark = pytest.mark.requires_rmq
+pytestmark = pytest.mark.requires_broker
 
 
 def format_local_time(timestamp, format_str='%Y-%m-%d %H:%M:%S'):

--- a/tests/cmdline/commands/test_data.py
+++ b/tests/cmdline/commands/test_data.py
@@ -233,7 +233,7 @@ class TestVerdiDataArray:
         assert res.exit_code == 0, 'The command did not finish correctly'
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestVerdiDataBands(DummyVerdiDataListable):
     """Testing verdi data core.bands."""
 

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -51,10 +51,9 @@ def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch):
         assert profile.process_control_backend is None
 
 
-@pytest.mark.requires_broker
 @pytest.mark.usefixtures('empty_config')
-def test_presto_with_rmq(pytestconfig, run_cli_command):
-    """Test the ``verdi presto``."""
+def test_presto(run_cli_command):
+    """Test that ``verdi presto`` configures a broker (RabbitMQ if available, otherwise ZMQ)."""
     result = run_cli_command(verdi_presto, ['--non-interactive'])
     assert 'Created new profile `presto`.' in result.output
 
@@ -62,7 +61,8 @@ def test_presto_with_rmq(pytestconfig, run_cli_command):
         assert profile.name == 'presto'
         localhost = Computer.collection.get(label='localhost')
         assert localhost.is_configured
-        assert profile.process_control_backend == 'core.rabbitmq'
+        # Presto auto-detects RabbitMQ, falls back to ZMQ if not available
+        assert profile.process_control_backend in ('core.rabbitmq', 'core.zmq')
 
 
 @pytest.mark.requires_psql

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -32,7 +32,7 @@ def test_get_default_presto_profile_name(monkeypatch, profile_names, expected):
 
 @pytest.mark.usefixtures('empty_config')
 def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch):
-    """Test the ``verdi presto`` without RabbitMQ."""
+    """Test the ``verdi presto`` without RabbitMQ falls back to ZMQ."""
     from aiida.brokers.rabbitmq import defaults
 
     def detect_rabbitmq_config(**kwargs):
@@ -48,7 +48,8 @@ def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch):
         assert profile.name == 'presto'
         localhost = Computer.collection.get(label='localhost')
         assert localhost.is_configured
-        assert profile.process_control_backend is None
+        # When RabbitMQ is not available, presto falls back to ZMQ broker
+        assert profile.process_control_backend == 'core.zmq'
 
 
 @pytest.mark.usefixtures('empty_config')

--- a/tests/cmdline/commands/test_presto.py
+++ b/tests/cmdline/commands/test_presto.py
@@ -51,7 +51,7 @@ def test_presto_without_rmq(pytestconfig, run_cli_command, monkeypatch):
         assert profile.process_control_backend is None
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('empty_config')
 def test_presto_with_rmq(pytestconfig, run_cli_command):
     """Test the ``verdi presto``."""

--- a/tests/cmdline/commands/test_process.py
+++ b/tests/cmdline/commands/test_process.py
@@ -141,7 +141,7 @@ def await_condition(condition: t.Callable, timeout: int = 1) -> t.Any:
     return result
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_kill_failing_transport(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
@@ -178,7 +178,7 @@ def test_process_kill_failing_transport(
         assert node.process_status == 'Force killed through `verdi process kill`'
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_kill_failing_transport_failed_kill(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
@@ -222,7 +222,7 @@ def test_process_kill_failing_transport_failed_kill(
         assert node.process_status == 'Force killed through `verdi process kill`'
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_kill_failing_ebm_transport(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
@@ -260,7 +260,7 @@ def test_process_kill_failing_ebm_transport(
         await_condition(lambda: node.is_killed, timeout=kill_timeout)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_kill_failing_ebm_kill(
     fork_worker_context, submit_and_await, aiida_code_installed, run_cli_command, monkeypatch
@@ -549,7 +549,7 @@ class TestVerdiProcess:
         assert result.exception is None, result.output
         assert len(result.output_lines) == 0
 
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_process_watch(self, run_cli_command):
         """Test verdi process watch"""
         # Running without identifiers should except and print something
@@ -779,7 +779,7 @@ class TestVerdiProcess:
 
 @pytest.mark.usefixtures('aiida_profile_clean')
 @pytest.mark.parametrize('numprocesses, percentage', ((0, 100), (1, 90)))
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_list_worker_slot_warning(run_cli_command, monkeypatch, numprocesses, percentage):
     """Test that the if the number of used worker process slots exceeds a threshold,
     that the warning message is displayed to the user when running `verdi process list`
@@ -876,7 +876,7 @@ class TestVerdiProcessCallRoot:
         assert len(result.output_lines) > 0
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_pause(submit_and_await, run_cli_command):
     """Test the ``verdi process pause`` command."""
@@ -893,7 +893,7 @@ def test_process_pause(submit_and_await, run_cli_command):
     assert len(result.output_lines) > 0
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_play(submit_and_await, run_cli_command):
     """Test the ``verdi process play`` command."""
@@ -912,7 +912,7 @@ def test_process_play(submit_and_await, run_cli_command):
     assert len(result.output_lines) > 0
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_play_all(submit_and_await, run_cli_command):
     """Test the ``verdi process play`` command with the ``--all`` option."""
@@ -928,7 +928,7 @@ def test_process_play_all(submit_and_await, run_cli_command):
     await_condition(lambda: not node_two.paused)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_kill(submit_and_await, run_cli_command, aiida_code_installed):
     """Test the ``verdi process kill`` command.
@@ -995,7 +995,7 @@ def test_process_kill(submit_and_await, run_cli_command, aiida_code_installed):
     assert node_2.process_status == 'Force killed through `verdi process kill`'
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('started_daemon_client')
 def test_process_kill_all(submit_and_await, run_cli_command):
     """Test the ``verdi process kill --all`` command."""

--- a/tests/cmdline/commands/test_run.py
+++ b/tests/cmdline/commands/test_run.py
@@ -20,7 +20,7 @@ from aiida.common.log import override_log_level
 class TestVerdiRun:
     """Tests for `verdi run`."""
 
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_run_workfunction(self, run_cli_command):
         """Regression test for #2165
 
@@ -159,7 +159,7 @@ class TestAutoGroups:
             all_auto_groups = queryb.all()
             assert len(all_auto_groups) == 0, 'There should be no autogroup generated'
 
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_autogroup_filter_class(self, run_cli_command):
         """Check if the autogroup is properly generated but filtered classes are skipped."""
         from aiida.orm import AutoGroup, Node, QueryBuilder, load_node

--- a/tests/cmdline/commands/test_status.py
+++ b/tests/cmdline/commands/test_status.py
@@ -17,7 +17,7 @@ from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.storage.psql_dos import migrator
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('stopped_daemon_client')
 def test_status(run_cli_command):
     """Test `verdi status`."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,9 @@ def pytest_collection_modifyitems(items, config):
     """Automatically generate markers for certain tests.
 
     Most notably, we add the 'presto' marker for all tests that
-    are not marked with either requires_broker or requires_psql.
+    are not marked with requires_rmq, requires_psql, or nightly.
+    Tests marked requires_broker are included in presto since ZMQ
+    broker is available without external services.
     """
     filepath_psqldos = Path(__file__).parent / 'storage' / 'psql_dos'
     filepath_django = Path(__file__).parent / 'storage' / 'psql_dos' / 'migrations' / 'django_branch'
@@ -114,11 +116,12 @@ def pytest_collection_modifyitems(items, config):
         if filepath_item.is_relative_to(filepath_psqldos):
             item.add_marker('requires_psql')
 
-        # Add 'presto' marker to tests that require no external services (no PSQL, no broker).
+        # Add 'presto' marker to tests that don't need external services.
+        # Tests with requires_broker ARE included (ZMQ broker needs no external service).
+        # Tests with requires_rmq, requires_psql, or nightly are excluded.
         markers = [marker.name for marker in item.iter_markers()]
         if (
-            'requires_broker' not in markers
-            and 'requires_rmq' not in markers
+            'requires_rmq' not in markers
             and 'requires_psql' not in markers
             and 'nightly' not in markers
         ):
@@ -189,8 +192,8 @@ def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql
 
     # Determine broker based on CLI option and markers
     if 'presto' in marker_opts:
-        # Presto tests don't use a broker
-        broker = None
+        # Presto tests use ZMQ broker (no external service required)
+        broker = 'core.zmq'
     elif broker_backend is TestBrokerBackend.RMQ:
         broker = 'core.rabbitmq'
     elif broker_backend is TestBrokerBackend.ZMQ:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,14 @@ class TestDbBackend(Enum):
     PSQL = 'psql'
 
 
+class TestBrokerBackend(Enum):
+    """Options for the '--broker-backend' CLI argument when running pytest."""
+
+    RMQ = 'rmq'
+    ZMQ = 'zmq'
+    NONE = 'none'
+
+
 def pytest_collection_modifyitems(items, config):
     """Automatically generate markers for certain tests.
 
@@ -73,6 +81,23 @@ def pytest_collection_modifyitems(items, config):
         else:
             config.option.markexpr = 'not requires_psql'
 
+    # Handle broker backend selection
+    broker_backend = config.option.broker_backend
+
+    # If using ZMQ, skip tests that specifically require RabbitMQ
+    if broker_backend is TestBrokerBackend.ZMQ:
+        if config.option.markexpr != '':
+            config.option.markexpr += ' and (not requires_rmq)'
+        else:
+            config.option.markexpr = 'not requires_rmq'
+
+    # If no broker, skip all tests that require any broker (RMQ-specific or general broker tests)
+    if broker_backend is TestBrokerBackend.NONE:
+        if config.option.markexpr != '':
+            config.option.markexpr += ' and (not requires_rmq) and (not requires_broker)'
+        else:
+            config.option.markexpr = 'not requires_rmq and not requires_broker'
+
     for item in items:
         filepath_item = Path(item.fspath)
 
@@ -80,17 +105,22 @@ def pytest_collection_modifyitems(items, config):
         if filepath_item.is_relative_to(filepath_django) or filepath_item.is_relative_to(filepath_sqla):
             item.add_marker('nightly')
 
-        # Add 'requires_rmq' for all tests that depend 'daemon_client' and its dependant fixtures
+        # Add 'requires_broker' for tests that depend on 'daemon_client' fixture (works with RMQ or ZMQ)
         if 'daemon_client' in item.fixturenames:
-            item.add_marker('requires_rmq')
+            item.add_marker('requires_broker')
 
         # All tests in 'storage/psql_dos' require PostgreSQL
         if filepath_item.is_relative_to(filepath_psqldos):
             item.add_marker('requires_psql')
 
-        # Add 'presto' marker to all tests that require neither PostgreSQL nor RabbitMQ services.
+        # Add 'presto' marker to tests that require no external services (no PSQL, no broker).
         markers = [marker.name for marker in item.iter_markers()]
-        if 'requires_rmq' not in markers and 'requires_psql' not in markers and 'nightly' not in markers:
+        if (
+            'requires_rmq' not in markers
+            and 'requires_broker' not in markers
+            and 'requires_psql' not in markers
+            and 'nightly' not in markers
+        ):
             item.add_marker('presto')
 
 
@@ -107,6 +137,19 @@ def db_backend_type(string):
         raise pytest.UsageError(msg)
 
 
+def broker_backend_type(string):
+    """Conversion function for the custom '--broker-backend' pytest CLI option
+
+    :param string: String provided by the user via CLI
+    :returns: BrokerBackend enum corresponding to user input string
+    """
+    try:
+        return TestBrokerBackend(string)
+    except ValueError:
+        msg = f"Invalid --broker-backend option '{string}'\nMust be one of: {tuple(b.value for b in TestBrokerBackend)}"
+        raise pytest.UsageError(msg)
+
+
 def pytest_addoption(parser):
     parser.addoption(
         '--db-backend',
@@ -116,22 +159,42 @@ def pytest_addoption(parser):
         help=f'Database backend to be used for tests {tuple(db.value for db in TestDbBackend)}',
         type=db_backend_type,
     )
+    parser.addoption(
+        '--broker-backend',
+        action='store',
+        default=TestBrokerBackend.RMQ,
+        required=False,
+        help=f'Broker backend to be used for tests {tuple(b.value for b in TestBrokerBackend)}',
+        type=broker_backend_type,
+    )
 
 
 @pytest.fixture(scope='session')
 def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql_dos, config_sqlite_dos):
-    """Create and load a profile with ``core.psql_dos`` as a storage backend and RabbitMQ as the broker.
+    """Create and load a profile with the specified storage and broker backends.
 
     This overrides the ``aiida_profile`` fixture provided by ``aiida-core`` which runs with ``core.sqlite_dos`` and
     without broker. However, tests in this package make use of the daemon which requires a broker and the tests should
     be run against the main storage backend, which is ``core.sqlite_dos``.
+
+    The broker backend can be selected via the ``--broker-backend`` CLI option:
+    - ``rmq``: Use RabbitMQ (default, requires RabbitMQ service)
+    - ``zmq``: Use ZeroMQ (no external service required)
+    - ``none``: No broker (limited functionality, no daemon support)
     """
     marker_opts = pytestconfig.getoption('-m')
     db_backend = pytestconfig.getoption('--db-backend')
+    broker_backend = pytestconfig.getoption('--broker-backend')
 
-    # We use RabbitMQ broker by default unless 'presto' marker is specified
-    broker = 'core.rabbitmq'
-    if 'not requires_rmq' in marker_opts or 'presto' in marker_opts:
+    # Determine broker based on CLI option and markers
+    if 'presto' in marker_opts:
+        # Presto tests don't use a broker
+        broker = None
+    elif broker_backend is TestBrokerBackend.RMQ:
+        broker = 'core.rabbitmq'
+    elif broker_backend is TestBrokerBackend.ZMQ:
+        broker = 'core.zmq'
+    else:  # TestBrokerBackend.NONE
         broker = None
 
     if db_backend is TestDbBackend.SQLITE:
@@ -147,7 +210,19 @@ def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql
     with aiida_profile_factory(
         aiida_config, storage_backend=storage, storage_config=config, broker_backend=broker
     ) as profile:
-        yield profile
+        # Start ZMQ broker service if using ZMQ backend
+        if broker == 'core.zmq':
+            broker_instance = get_manager().get_broker()
+            if broker_instance is not None and hasattr(broker_instance, 'controller'):
+                broker_instance.controller.start()
+                try:
+                    yield profile
+                finally:
+                    broker_instance.controller.stop()
+            else:
+                yield profile
+        else:
+            yield profile
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def pytest_collection_modifyitems(items, config):
     """Automatically generate markers for certain tests.
 
     Most notably, we add the 'presto' marker for all tests that
-    are not marked with either requires_rmq or requires_psql.
+    are not marked with either requires_broker or requires_psql.
     """
     filepath_psqldos = Path(__file__).parent / 'storage' / 'psql_dos'
     filepath_django = Path(__file__).parent / 'storage' / 'psql_dos' / 'migrations' / 'django_branch'
@@ -84,19 +84,20 @@ def pytest_collection_modifyitems(items, config):
     # Handle broker backend selection
     broker_backend = config.option.broker_backend
 
-    # If using ZMQ, skip tests that specifically require RabbitMQ
+    # If using ZMQ, skip tests that specifically require RabbitMQ (requires_rmq marker)
+    # but allow tests with requires_broker marker (they work with any broker)
     if broker_backend is TestBrokerBackend.ZMQ:
         if config.option.markexpr != '':
             config.option.markexpr += ' and (not requires_rmq)'
         else:
             config.option.markexpr = 'not requires_rmq'
 
-    # If no broker, skip all tests that require any broker (RMQ-specific or general broker tests)
+    # If no broker, skip all tests that require any broker (both RMQ-specific and general broker tests)
     if broker_backend is TestBrokerBackend.NONE:
         if config.option.markexpr != '':
-            config.option.markexpr += ' and (not requires_rmq) and (not requires_broker)'
+            config.option.markexpr += ' and (not requires_broker) and (not requires_rmq)'
         else:
-            config.option.markexpr = 'not requires_rmq and not requires_broker'
+            config.option.markexpr = 'not requires_broker and not requires_rmq'
 
     for item in items:
         filepath_item = Path(item.fspath)
@@ -116,8 +117,8 @@ def pytest_collection_modifyitems(items, config):
         # Add 'presto' marker to tests that require no external services (no PSQL, no broker).
         markers = [marker.name for marker in item.iter_markers()]
         if (
-            'requires_rmq' not in markers
-            and 'requires_broker' not in markers
+            'requires_broker' not in markers
+            and 'requires_rmq' not in markers
             and 'requires_psql' not in markers
             and 'nightly' not in markers
         ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,12 +217,12 @@ def aiida_profile(pytestconfig, aiida_config, aiida_profile_factory, config_psql
         # Start ZMQ broker service if using ZMQ backend
         if broker == 'core.zmq':
             broker_instance = get_manager().get_broker()
-            if broker_instance is not None and hasattr(broker_instance, 'controller'):
-                broker_instance.controller.start()
+            if broker_instance is not None and hasattr(broker_instance, 'management_client'):
+                broker_instance.management_client.start()
                 try:
                     yield profile
                 finally:
-                    broker_instance.controller.stop()
+                    broker_instance.management_client.stop()
             else:
                 yield profile
         else:

--- a/tests/engine/daemon/test_client.py
+++ b/tests/engine/daemon/test_client.py
@@ -20,7 +20,7 @@ from aiida.engine.daemon.client import (
     get_daemon_client,
 )
 
-pytestmark = pytest.mark.requires_rmq
+pytestmark = pytest.mark.requires_broker
 
 
 def test_ipc_socket_file_length_limit():

--- a/tests/engine/daemon/test_worker.py
+++ b/tests/engine/daemon/test_worker.py
@@ -15,7 +15,7 @@ from aiida.orm import Log
 from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.asyncio
 async def test_shutdown_worker(manager):
     """Test the ``shutdown_worker`` method."""

--- a/tests/engine/processes/calcjobs/test_calc_job.py
+++ b/tests/engine/processes/calcjobs/test_calc_job.py
@@ -57,7 +57,7 @@ def get_calcjob_builder(aiida_code_installed):
     return _factory
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class DummyCalcJob(CalcJob):
     """`DummyCalcJob` implementation to test the calcinfo with container code."""
 
@@ -81,7 +81,7 @@ class DummyCalcJob(CalcJob):
         return calcinfo
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class FileCalcJob(CalcJob):
     """Example `CalcJob` implementation to test the `provenance_exclude_list` functionality.
 
@@ -119,7 +119,7 @@ class FileCalcJob(CalcJob):
         return calcinfo
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class MultiCodesCalcJob(CalcJob):
     """`MultiCodesCalcJob` implementation to test the calcinfo with multiple codes set.
 
@@ -250,7 +250,7 @@ def test_multi_codes_with_mpi(
     assert len(job_tmpl['codes_info'][0]['prepend_cmdline_params']) == expected
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('chdir_tmp_path')
 @pytest.mark.parametrize('parallel_run', [True, False])
 def test_multi_codes_run_parallel(aiida_code_installed, file_regression, parallel_run):
@@ -279,7 +279,7 @@ def test_multi_codes_run_parallel(aiida_code_installed, file_regression, paralle
     file_regression.check(content, extension='.sh')
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('chdir_tmp_path')
 @pytest.mark.parametrize('computer_use_double_quotes', [True, False])
 def test_computer_double_quotes(
@@ -311,7 +311,7 @@ def test_computer_double_quotes(
     file_regression.check(content, extension='.sh')
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('chdir_tmp_path')
 @pytest.mark.parametrize('code_use_double_quotes', [True, False])
 def test_code_double_quotes(aiida_localhost, file_regression, code_use_double_quotes):
@@ -338,7 +338,7 @@ def test_code_double_quotes(aiida_localhost, file_regression, code_use_double_qu
     file_regression.check(content, extension='.sh')
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('chdir_tmp_path')
 def test_containerized_code(file_regression, aiida_localhost):
     """Test the :class:`~aiida.orm.nodes.data.code.containerized.ContainerizedCode`."""
@@ -371,7 +371,7 @@ def test_containerized_code(file_regression, aiida_localhost):
     file_regression.check(content, extension='.sh')
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('chdir_tmp_path')
 def test_containerized_code_wrap_cmdline_params(file_regression, aiida_localhost):
     """Test :class:`~aiida.orm.nodes.data.code.containerized.ContainerizedCode` with ``wrap_cmdline_params = True``."""
@@ -405,7 +405,7 @@ def test_containerized_code_wrap_cmdline_params(file_regression, aiida_localhost
     file_regression.check(content, extension='.sh')
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('chdir_tmp_path')
 def test_containerized_code_withmpi_true(file_regression, aiida_localhost):
     """Test the :class:`~aiida.orm.nodes.data.code.containerized.ContainerizedCode` with ``withmpi=True``."""
@@ -438,7 +438,7 @@ def test_containerized_code_withmpi_true(file_regression, aiida_localhost):
     file_regression.check(content, extension='.sh')
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('chdir_tmp_path')
 def test_portable_code(tmp_path, aiida_localhost):
     """Test run container code"""
@@ -484,7 +484,7 @@ def test_portable_code(tmp_path, aiida_localhost):
     assert subsubcontent == 'sub dummy'
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestCalcJob:
     """Test for the `CalcJob` process sub class."""
 
@@ -855,7 +855,7 @@ def generate_process(aiida_code_installed):
     return _generate_process
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('override_logging')
 def test_parse_insufficient_data(generate_process):
     """Test the scheduler output parsing logic in `CalcJob.parse`.
@@ -886,7 +886,7 @@ def test_parse_insufficient_data(generate_process):
         assert log in logs
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('override_logging')
 def test_parse_non_zero_retval(generate_process):
     """Test the scheduler output parsing logic in `CalcJob.parse`.
@@ -906,7 +906,7 @@ def test_parse_non_zero_retval(generate_process):
     assert 'could not parse scheduler output: return value of `detailed_job_info` is non-zero' in logs
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('override_logging')
 def test_parse_not_implemented(generate_process):
     """Test the scheduler output parsing logic in `CalcJob.parse`.
@@ -938,7 +938,7 @@ def test_parse_not_implemented(generate_process):
         assert log in logs
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.usefixtures('override_logging')
 def test_parse_scheduler_excepted(generate_process, monkeypatch):
     """Test the scheduler output parsing logic in `CalcJob.parse`.
@@ -976,7 +976,7 @@ def test_parse_scheduler_excepted(generate_process, monkeypatch):
         assert log in logs
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.parametrize(
     ('exit_status_scheduler', 'exit_status_retrieved', 'final'),
     (
@@ -1046,7 +1046,7 @@ def test_parse_exit_code_priority(
     assert result.status == final
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_additional_retrieve_list(generate_process, fixture_sandbox):
     """Test the ``additional_retrieve_list`` option."""
     process = generate_process()
@@ -1342,7 +1342,7 @@ def test_submit_return_exit_code(get_calcjob_builder, monkeypatch):
     assert node.exit_status == 418
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_restart_after_daemon_reset(get_calcjob_builder, daemon_client, submit_and_await):
     """Test that a job can be restarted when it is launched and the daemon is restarted.
 

--- a/tests/engine/processes/workchains/test_restart.py
+++ b/tests/engine/processes/workchains/test_restart.py
@@ -94,7 +94,7 @@ def test_get_process_handlers_by_priority(generate_work_chain, inputs, prioritie
     ]
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_excepted_process(generate_work_chain, generate_calculation_node):
     """Test that the workchain aborts if the sub process was excepted."""
     process = generate_work_chain(SomeWorkChain, {})
@@ -103,7 +103,7 @@ def test_excepted_process(generate_work_chain, generate_calculation_node):
     assert process.inspect_process() == engine.BaseRestartWorkChain.exit_codes.ERROR_SUB_PROCESS_EXCEPTED
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_killed_process(generate_work_chain, generate_calculation_node):
     """Test that the workchain aborts if the sub process was killed."""
     process = generate_work_chain(SomeWorkChain, {})
@@ -112,7 +112,7 @@ def test_killed_process(generate_work_chain, generate_calculation_node):
     assert process.inspect_process() == engine.BaseRestartWorkChain.exit_codes.ERROR_SUB_PROCESS_KILLED
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 @pytest.mark.parametrize('on_unhandled_failure', (None, 'abort', 'pause', 'restart_once', 'restart_and_pause'))
 def test_unhandled_failure(generate_work_chain, generate_calculation_node, on_unhandled_failure):
     """Test the `on_unhandled_failure` input and behavior."""
@@ -141,7 +141,7 @@ def test_unhandled_failure(generate_work_chain, generate_calculation_node, on_un
         assert process.paused
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_unhandled_reset_after_success(generate_work_chain, generate_calculation_node):
     """Test `ctx.unhandled_failure` is reset to `False` in `inspect_process` after a successful process."""
     process = generate_work_chain(SomeWorkChain, {'on_unhandled_failure': orm.Str('restart_once')})
@@ -155,7 +155,7 @@ def test_unhandled_reset_after_success(generate_work_chain, generate_calculation
     assert process.ctx.unhandled_failure is False
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_unhandled_reset_after_handled(generate_work_chain, generate_calculation_node):
     """Test `ctx.unhandled_failure` is reset to `False` in `inspect_process` after a handled failed process."""
     process = generate_work_chain(SomeWorkChain, {'on_unhandled_failure': orm.Str('restart_once')})
@@ -176,7 +176,7 @@ def test_unhandled_reset_after_handled(generate_work_chain, generate_calculation
     assert process.ctx.unhandled_failure is False
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_run_process(generate_work_chain, generate_calculation_node, monkeypatch):
     """Test the `run_process` method."""
 
@@ -244,14 +244,14 @@ class CustomBaseRestartWorkChain(engine.BaseRestartWorkChain):
             self.ctx.inputs.parameters = self.ctx.inputs.parameters.get_dict()
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_results():
     results, node = engine.launch.run_get_node(CustomBaseRestartWorkChain)
     assert results['sub'].result.value == 1
     assert node.exit_status == 11
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_wrap_bare_dict_inputs():
     """Test that ``BaseRestartWorkChain._wrap_bare_dict_inputs`` method works properly.
 

--- a/tests/engine/processes/workchains/test_utils.py
+++ b/tests/engine/processes/workchains/test_utils.py
@@ -19,7 +19,7 @@ from aiida.plugins import CalculationFactory
 ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestRegisterProcessHandler:
     """Tests for the `process_handler` decorator."""
 

--- a/tests/engine/test_calcfunctions.py
+++ b/tests/engine/test_calcfunctions.py
@@ -37,7 +37,7 @@ def execution_counter_calcfunction(data):
     return Int(data.value + 1)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestCalcFunction:
     """Tests for calcfunctions.
 

--- a/tests/engine/test_futures.py
+++ b/tests/engine/test_futures.py
@@ -17,7 +17,7 @@ from aiida.manage import get_manager
 from tests.utils import processes as test_processes
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestWf:
     """Test process futures."""
 

--- a/tests/engine/test_launch.py
+++ b/tests/engine/test_launch.py
@@ -131,7 +131,7 @@ def test_await_processes(aiida_code_installed, caplog):
     assert 'out of 1 processes terminated.' in caplog.records[0].message
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestLaunchers:
     """Class to test process launchers."""
 
@@ -210,7 +210,7 @@ class TestLaunchers:
             launch.submit(AddWorkChain, term_a=self.term_a, term_b=self.term_b, metadata={'store_provenance': False})
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestLaunchersDryRun:
     """Test the launchers when performing a dry-run."""
 

--- a/tests/engine/test_persistence.py
+++ b/tests/engine/test_persistence.py
@@ -16,7 +16,7 @@ from aiida.engine.persistence import AiiDAPersister
 from tests.utils.processes import DummyProcess
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestProcess:
     """Test the basic saving and loading of process states."""
 
@@ -39,7 +39,7 @@ class TestProcess:
         assert loaded_process.state == plumpy.ProcessState.FINISHED
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestAiiDAPersister:
     """Test AiiDAPersister."""
 

--- a/tests/engine/test_process.py
+++ b/tests/engine/test_process.py
@@ -36,7 +36,7 @@ class NameSpacedProcess(Process):
         spec.input('some.name.space.a', valid_type=orm.Int)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestProcessNamespace:
     """Test process namespace"""
 
@@ -94,7 +94,7 @@ class ProcessStackTest(Process):
         assert self._thread_id is threading.current_thread().ident
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestProcess:
     """Test AiiDA process."""
 

--- a/tests/engine/test_process_function.py
+++ b/tests/engine/test_process_function.py
@@ -36,7 +36,7 @@ DEFAULT_DESCRIPTION = 'Default description'
 CUSTOM_LABEL = 'Custom label'
 CUSTOM_DESCRIPTION = 'Custom description'
 
-pytest.mark.requires_rmq
+pytest.mark.requires_broker
 
 
 @workfunction
@@ -441,7 +441,7 @@ def test_run_launchers():
     assert isinstance(node, orm.CalcFunctionNode)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_submit_launchers():
     """Verify that submit to daemon works."""
     # Process function can be submitted and will be run by a daemon worker as long as the function is importable

--- a/tests/engine/test_run.py
+++ b/tests/engine/test_run.py
@@ -15,7 +15,7 @@ from aiida.orm import Int, ProcessNode, Str
 from tests.utils.processes import DummyProcess
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestRun:
     """Tests for the `run` functions."""
 

--- a/tests/engine/test_runners.py
+++ b/tests/engine/test_runners.py
@@ -46,7 +46,7 @@ def the_hans_klok_comeback(loop):
     loop.stop()
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_call_on_process_finish(runner):
     """Test call on calculation finish."""
     loop = runner.loop

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -173,7 +173,7 @@ class TestInterruptable:
         assert future.done()
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestInterruptableTask:
     """Tests for InterruptableFuture and interruptable_task."""
 

--- a/tests/engine/test_work_chain.py
+++ b/tests/engine/test_work_chain.py
@@ -223,7 +223,7 @@ class PotentialFailureWorkChain(WorkChain):
         self.out(self.OUTPUT_LABEL, Int(self.OUTPUT_VALUE).store())
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestExitStatus:
     """This class should test the various ways that one can exit from the outline flow of a WorkChain, other than
     it running it all the way through. Currently this can be done directly in the outline by calling the `return_`
@@ -303,7 +303,7 @@ class IfTest(WorkChain):
         self.ctx.s2 = True
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestContext:
     def test_attributes(self):
         wc = IfTest()
@@ -324,7 +324,7 @@ class TestContext:
             wc.ctx['new_attr']
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestWorkchain:
     @pytest.fixture(autouse=True)
     def init_profile(self):
@@ -1099,7 +1099,7 @@ class TestWorkchain:
         assert node.outputs.out_static == 3
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestWorkChainAbort:
     """Test the functionality to abort a workchain"""
 
@@ -1170,7 +1170,7 @@ class TestWorkChainAbort:
         assert process.node.is_killed is True
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestWorkChainAbortChildren:
     """Test the functionality to abort a workchain and verify that children
     are also aborted appropriately
@@ -1255,7 +1255,7 @@ class TestWorkChainAbortChildren:
         assert process.node.is_killed is True
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestImmutableInputWorkchain:
     """Test that inputs cannot be modified"""
 
@@ -1349,7 +1349,7 @@ class SerializeWorkChain(WorkChain):
         assert self.inputs.test == self.inputs.reference
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestSerializeWorkChain:
     """Test workchains with serialized input / output."""
 
@@ -1467,7 +1467,7 @@ class ChildExposeWorkChain(WorkChain):
         self.out('c', self.inputs.c)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestWorkChainExpose:
     """Test the expose inputs / outputs functionality"""
 
@@ -1563,7 +1563,7 @@ class TestWorkChainExpose:
         assert input_namespace['b'].help == 'An integer argument.'
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestWorkChainMisc:
     class PointlessWorkChain(WorkChain):
         @classmethod
@@ -1598,7 +1598,7 @@ class TestWorkChainMisc:
             launch.run(TestWorkChainMisc.IllegalSubmitWorkChain)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestDefaultUniqueness:
     """Test that default inputs of exposed nodes will get unique UUIDS."""
 

--- a/tests/engine/test_workfunctions.py
+++ b/tests/engine/test_workfunctions.py
@@ -16,7 +16,7 @@ from aiida.manage.caching import enable_caching
 from aiida.orm import CalcFunctionNode, Int, WorkFunctionNode
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 class TestWorkFunction:
     """Tests for workfunctions.
 

--- a/tests/engine/test_zmq.py
+++ b/tests/engine/test_zmq.py
@@ -1,0 +1,175 @@
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida-core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Module to test ZMQ broker process control.
+
+These tests mirror tests/engine/test_rmq.py but use the requires_broker marker
+so they run with the ZMQ broker backend.
+"""
+
+import asyncio
+
+import plumpy
+import pytest
+
+from aiida.engine import ProcessState
+from aiida.manage import get_manager
+from aiida.orm import Int
+from tests.utils import processes as test_processes
+
+
+@pytest.mark.requires_broker
+class TestProcessControl:
+    """Test process control with ZMQ broker."""
+
+    TIMEOUT = 2.0
+
+    @pytest.fixture(autouse=True)
+    def init_profile(self):
+        """Initialize the profile."""
+        manager = get_manager()
+        self.runner = manager.get_runner()
+
+    def test_submit_simple(self):
+        """Launch a simple process."""
+
+        async def do_submit():
+            calc_node = self.runner.submit(test_processes.DummyProcess)
+            await self.wait_for_process(calc_node)
+
+            assert calc_node.is_finished_ok
+            assert calc_node.process_state.value == plumpy.ProcessState.FINISHED.value
+
+        self.runner.loop.run_until_complete(do_submit())
+
+    def test_launch_with_inputs(self):
+        """Test launch with inputs."""
+
+        async def do_launch():
+            term_a = Int(5)
+            term_b = Int(10)
+
+            calc_node = self.runner.submit(test_processes.AddProcess, a=term_a, b=term_b)
+            await self.wait_for_process(calc_node)
+            assert calc_node.is_finished_ok
+            assert calc_node.process_state.value == plumpy.ProcessState.FINISHED.value
+
+        self.runner.loop.run_until_complete(do_launch())
+
+    def test_submit_bad_input(self):
+        """Test that submitting with bad input raises ValueError."""
+        with pytest.raises(ValueError):
+            self.runner.submit(test_processes.AddProcess, a=Int(5))
+
+    def test_exception_process(self):
+        """Test process that raises an exception."""
+
+        async def do_exception():
+            calc_node = self.runner.submit(test_processes.ExceptionProcess)
+            await self.wait_for_process(calc_node)
+
+            assert not calc_node.is_finished_ok
+            assert calc_node.process_state.value == plumpy.ProcessState.EXCEPTED.value
+
+        self.runner.loop.run_until_complete(do_exception())
+
+    def test_pause(self):
+        """Test sending a pause message to the process."""
+        controller = get_manager().get_process_controller()
+
+        async def do_pause():
+            calc_node = self.runner.submit(test_processes.WaitProcess)
+            while calc_node.process_state != ProcessState.WAITING:
+                await asyncio.sleep(0.1)
+
+            assert not calc_node.paused
+
+            pause_future = controller.pause_process(calc_node.pk)
+            future = await with_timeout(asyncio.wrap_future(pause_future))
+            result = await self.wait_future(asyncio.wrap_future(future))
+            assert result
+            assert calc_node.paused
+
+            kill_future = controller.kill_process(calc_node.pk, msg_text='Sorry, you have to go mate')
+            future = await with_timeout(asyncio.wrap_future(kill_future))
+            result = await self.wait_future(asyncio.wrap_future(future))
+            assert result
+
+        self.runner.loop.run_until_complete(do_pause())
+
+    def test_pause_play(self):
+        """Test sending a pause and then a play message."""
+        controller = get_manager().get_process_controller()
+
+        async def do_pause_play():
+            calc_node = self.runner.submit(test_processes.WaitProcess)
+            assert not calc_node.paused
+            while calc_node.process_state != ProcessState.WAITING:
+                await asyncio.sleep(0.1)
+
+            pause_message = 'Take a seat'
+            pause_future = controller.pause_process(calc_node.pk, msg_text=pause_message)
+            future = await with_timeout(asyncio.wrap_future(pause_future))
+            result = await self.wait_future(asyncio.wrap_future(future))
+            assert calc_node.paused
+            assert calc_node.process_status == pause_message
+
+            play_future = controller.play_process(calc_node.pk)
+            future = await with_timeout(asyncio.wrap_future(play_future))
+            result = await self.wait_future(asyncio.wrap_future(future))
+
+            assert result
+            assert not calc_node.paused
+            assert calc_node.process_status is None
+
+            kill_future = controller.kill_process(calc_node.pk, msg_text='Sorry, you have to go mate')
+            future = await with_timeout(asyncio.wrap_future(kill_future))
+            result = await self.wait_future(asyncio.wrap_future(future))
+            assert result
+
+        self.runner.loop.run_until_complete(do_pause_play())
+
+    def test_kill(self):
+        """Test sending a kill message."""
+        controller = get_manager().get_process_controller()
+
+        async def do_kill():
+            calc_node = self.runner.submit(test_processes.WaitProcess)
+            assert not calc_node.is_killed
+            while calc_node.process_state != ProcessState.WAITING:
+                await asyncio.sleep(0.1)
+
+            kill_message = 'Sorry, you have to go mate'
+            kill_future = controller.kill_process(calc_node.pk, msg_text=kill_message)
+            future = await with_timeout(asyncio.wrap_future(kill_future))
+            result = await self.wait_future(asyncio.wrap_future(future))
+            assert result
+
+            await self.wait_for_process(calc_node)
+            assert calc_node.is_killed
+            assert calc_node.process_status == kill_message
+
+        self.runner.loop.run_until_complete(do_kill())
+
+    async def wait_for_process(self, calc_node, timeout=2.0):
+        """Wait for a process to finish."""
+        future = self.runner.get_process_future(calc_node.pk)
+        result = await with_timeout(future, timeout)
+        return result
+
+    @staticmethod
+    async def wait_future(future, timeout=2.0):
+        """Wait for a future with timeout."""
+        result = await with_timeout(future, timeout)
+        return result
+
+
+async def with_timeout(what, timeout=5.0):
+    """Wait for a coroutine with timeout."""
+    result = await asyncio.wait_for(what, timeout)
+    return result

--- a/tests/engine/test_zmq.py
+++ b/tests/engine/test_zmq.py
@@ -90,14 +90,12 @@ class TestProcessControl:
             assert not calc_node.paused
 
             pause_future = controller.pause_process(calc_node.pk)
-            future = await with_timeout(asyncio.wrap_future(pause_future))
-            result = await self.wait_future(asyncio.wrap_future(future))
+            result = await with_timeout(asyncio.wrap_future(pause_future))
             assert result
             assert calc_node.paused
 
             kill_future = controller.kill_process(calc_node.pk, msg_text='Sorry, you have to go mate')
-            future = await with_timeout(asyncio.wrap_future(kill_future))
-            result = await self.wait_future(asyncio.wrap_future(future))
+            result = await with_timeout(asyncio.wrap_future(kill_future))
             assert result
 
         self.runner.loop.run_until_complete(do_pause())
@@ -114,22 +112,19 @@ class TestProcessControl:
 
             pause_message = 'Take a seat'
             pause_future = controller.pause_process(calc_node.pk, msg_text=pause_message)
-            future = await with_timeout(asyncio.wrap_future(pause_future))
-            result = await self.wait_future(asyncio.wrap_future(future))
+            result = await with_timeout(asyncio.wrap_future(pause_future))
             assert calc_node.paused
             assert calc_node.process_status == pause_message
 
             play_future = controller.play_process(calc_node.pk)
-            future = await with_timeout(asyncio.wrap_future(play_future))
-            result = await self.wait_future(asyncio.wrap_future(future))
+            result = await with_timeout(asyncio.wrap_future(play_future))
 
             assert result
             assert not calc_node.paused
             assert calc_node.process_status is None
 
             kill_future = controller.kill_process(calc_node.pk, msg_text='Sorry, you have to go mate')
-            future = await with_timeout(asyncio.wrap_future(kill_future))
-            result = await self.wait_future(asyncio.wrap_future(future))
+            result = await with_timeout(asyncio.wrap_future(kill_future))
             assert result
 
         self.runner.loop.run_until_complete(do_pause_play())
@@ -146,8 +141,7 @@ class TestProcessControl:
 
             kill_message = 'Sorry, you have to go mate'
             kill_future = controller.kill_process(calc_node.pk, msg_text=kill_message)
-            future = await with_timeout(asyncio.wrap_future(kill_future))
-            result = await self.wait_future(asyncio.wrap_future(future))
+            result = await with_timeout(asyncio.wrap_future(kill_future))
             assert result
 
             await self.wait_for_process(calc_node)
@@ -161,13 +155,6 @@ class TestProcessControl:
         future = self.runner.get_process_future(calc_node.pk)
         result = await with_timeout(future, timeout)
         return result
-
-    @staticmethod
-    async def wait_future(future, timeout=2.0):
-        """Wait for a future with timeout."""
-        result = await with_timeout(future, timeout)
-        return result
-
 
 async def with_timeout(what, timeout=5.0):
     """Wait for a coroutine with timeout."""

--- a/tests/manage/test_manager.py
+++ b/tests/manage/test_manager.py
@@ -10,7 +10,7 @@ def add_calcfunction(data):
     return orm.Int(data.value + 1)
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_disconnect():
     """Test the communicator disconnect.
 

--- a/tests/orm/test_querybuilder.py
+++ b/tests/orm/test_querybuilder.py
@@ -125,7 +125,7 @@ class TestBasic:
 
     # Tracked in issue #4281
     @pytest.mark.flaky(reruns=2)
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     @pytest.mark.usefixtures('aiida_profile_clean')
     def test_process_query(self):
         """Test querying for a process class."""

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -111,7 +111,7 @@ class TestParser:
         assert 'output' in outputs_for_parsing
         assert outputs_for_parsing['output'].uuid == output.uuid
 
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_parse_from_node(self):
         """Test that the `parse_from_node` returns a tuple of the parsed output nodes and a calculation node.
 
@@ -144,7 +144,7 @@ class TestParser:
         # Verify that the `retrieved_temporary_folder` keyword can be passed, there is no validation though
         result, calcfunction = ArithmeticAddParser.parse_from_node(node, retrieved_temporary_folder='/some/path')
 
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_parse_from_node_output_validation(self):
         """Test that the ``parse_from_node`` properly validates attached outputs.
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -205,7 +205,7 @@ class TestCifData:
 
     @skip_ase
     @skip_pycifrw
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     @pytest.mark.filterwarnings('ignore:Cannot determine chemical composition from CIF:UserWarning:pymatgen.io')
     def test_get_structure(self):
         """Test `CifData.get_structure`."""
@@ -244,7 +244,7 @@ O 0.5 0.5 0.5
 
     @skip_ase
     @skip_pycifrw
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_ase_primitive_and_conventional_cells_ase(self):
         """Checking the number of atoms per primitive/conventional cell
         returned by ASE ase.io.read() method. Test input is
@@ -287,7 +287,7 @@ O 0.5 0.5 0.5
     @skip_ase
     @skip_pycifrw
     @skip_pymatgen
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     @pytest.mark.filterwarnings('ignore:Cannot determine chemical composition from CIF:UserWarning:pymatgen.io')
     def test_ase_primitive_and_conventional_cells_pymatgen(self):
         """Checking the number of atoms per primitive/conventional cell
@@ -548,7 +548,7 @@ _tag   {'a' * 5000}
     @skip_ase
     @skip_pycifrw
     @skip_spglib
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_refine(self):
         """Test case for refinement (space group determination) for a
         CifData object.
@@ -1599,7 +1599,7 @@ class TestStructureData:
 
     @skip_ase
     @skip_pycifrw
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_get_cif(self):
         """Tests the conversion to CifData"""
         import re
@@ -2878,7 +2878,7 @@ class TestTrajectoryData:
             # Step 66 does not exist
             n.get_index_from_stepid(66)
 
-    @pytest.mark.requires_rmq
+    @pytest.mark.requires_broker
     def test_conversion_to_structure(self):
         """Check the methods to export a given time step to a StructureData node."""
         # Create a node with two arrays

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -12,7 +12,7 @@ def test_presto_auto_mark(request):
 
 @pytest.mark.sphinx
 def test_presto_mark_and_another_mark(request):
-    """Test that presto marker is added even if there is an existing marker (except requires_rmq|psql)"""
+    """Test that presto marker is added even if there is an existing marker (except requires_broker|psql)"""
     own_markers = [marker.name for marker in request.node.own_markers]
 
     assert len(own_markers) == 2
@@ -20,13 +20,13 @@ def test_presto_mark_and_another_mark(request):
     assert 'sphinx' in own_markers
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_no_presto_mark_if_rmq(request):
-    """Test that presto marker is NOT added if the test is mark with "requires_rmq"""
+    """Test that presto marker is NOT added if the test is mark with "requires_broker"""
     own_markers = [marker.name for marker in request.node.own_markers]
 
     assert len(own_markers) == 1
-    assert own_markers[0] == 'requires_rmq'
+    assert own_markers[0] == 'requires_broker'
 
 
 @pytest.mark.requires_psql
@@ -56,9 +56,9 @@ def test_requires_psql_with_sqlite_impossible(pytestconfig):
 
 def test_daemon_client_fixture_automarked(request, daemon_client):
     """Test that any test using ``daemon_client`` fixture is
-    automatically tagged with 'requires_rmq' mark
+    automatically tagged with 'requires_broker' mark
     """
     own_markers = [marker.name for marker in request.node.own_markers]
 
     assert len(own_markers) == 1
-    assert own_markers[0] == 'requires_rmq'
+    assert own_markers[0] == 'requires_broker'

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -12,7 +12,7 @@ def test_presto_auto_mark(request):
 
 @pytest.mark.sphinx
 def test_presto_mark_and_another_mark(request):
-    """Test that presto marker is added even if there is an existing marker (except requires_broker|psql)"""
+    """Test that presto marker is added even if there is an existing marker (except requires_rmq|psql)"""
     own_markers = [marker.name for marker in request.node.own_markers]
 
     assert len(own_markers) == 2
@@ -21,12 +21,22 @@ def test_presto_mark_and_another_mark(request):
 
 
 @pytest.mark.requires_broker
+def test_presto_mark_with_requires_broker(request):
+    """Test that presto marker IS added for requires_broker tests (ZMQ needs no external service)"""
+    own_markers = [marker.name for marker in request.node.own_markers]
+
+    assert len(own_markers) == 2
+    assert 'requires_broker' in own_markers
+    assert 'presto' in own_markers
+
+
+@pytest.mark.requires_rmq
 def test_no_presto_mark_if_rmq(request):
-    """Test that presto marker is NOT added if the test is mark with "requires_broker"""
+    """Test that presto marker is NOT added if the test is marked with "requires_rmq"""
     own_markers = [marker.name for marker in request.node.own_markers]
 
     assert len(own_markers) == 1
-    assert own_markers[0] == 'requires_broker'
+    assert own_markers[0] == 'requires_rmq'
 
 
 @pytest.mark.requires_psql
@@ -56,9 +66,10 @@ def test_requires_psql_with_sqlite_impossible(pytestconfig):
 
 def test_daemon_client_fixture_automarked(request, daemon_client):
     """Test that any test using ``daemon_client`` fixture is
-    automatically tagged with 'requires_broker' mark
+    automatically tagged with 'requires_broker' mark (and also gets 'presto')
     """
     own_markers = [marker.name for marker in request.node.own_markers]
 
-    assert len(own_markers) == 1
-    assert own_markers[0] == 'requires_broker'
+    assert len(own_markers) == 2
+    assert 'requires_broker' in own_markers
+    assert 'presto' in own_markers

--- a/tests/tools/archive/migration/test_prov_redesign.py
+++ b/tests/tools/archive/migration/test_prov_redesign.py
@@ -82,7 +82,7 @@ def test_base_data_type_change(tmp_path, aiida_profile):
     assert nlist.node_type == 'data.core.list.List.', msg
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_node_process_type(aiida_profile, tmp_path):
     """Column `process_type` added to `Node` entity DB table"""
     from aiida.engine import run_get_node

--- a/tests/tools/archive/orm/test_calculations.py
+++ b/tests/tools/archive/orm/test_calculations.py
@@ -17,7 +17,7 @@ from aiida.engine import calcfunction
 from aiida.tools.archive import create_archive, import_archive
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_calcfunction(tmp_path, aiida_profile):
     """Test @calcfunction"""
     aiida_profile.reset_storage()

--- a/tests/workflows/arithmetic/test_add_multiply.py
+++ b/tests/workflows/arithmetic/test_add_multiply.py
@@ -21,7 +21,7 @@ def test_factory():
     assert loaded.is_process_function
 
 
-@pytest.mark.requires_rmq
+@pytest.mark.requires_broker
 def test_run():
     """Test running the work function."""
     x = Int(1)


### PR DESCRIPTION
### Structure of commits

The commits are can be categorized like this (hashes will mismatch because I still rebase frequently)

1. Broker module - Complete ZMQ broker implementation
```
0923b44bf Use YAML encoding for ZMQ broker messages
a54d22cba Add ZeroMQ-based message broker plugin
```

2. AiiDA CLI - New verdi broker commands plus `--broker option`
```
4a1f4bb52 Integrate ZMQ broker into profile creation
824f0a19d Add ZMQ broker entry point and verdi broker command
```

3. Tests - New ZMQ tests plus marker renames (requires_rmq → requires_broker)
```
8b823be31 Update test_presto_without_rmq to expect ZMQ fallback
d8891b474 Add tests for ZMQ broker
d0b04a4d7 Rename requires_rmq marker to requires_broker for broker-agnostic tests
2dc0dec17 Add --broker-backend pytest option for running tests with RMQ or ZMQ
419681375 Make test_presto broker-agnostic
```

4. CI (GitHub workflows) - Simplified to use ZMQ broker for presto profiles
```
33b09585f Use ZMQ broker in CI for presto profiles
```


### Lines of code breakdown

  | Category              | Files | Lines Added | Lines Removed | Net Change |
  |-----------------------|-------|-------------|---------------|------------|
  | CI (GitHub workflows) | 2     | +3          | -17           | -14        |
  | Tests                 | 37    | +707        | -112          | +595       |
  | AiiDA CLI             | 5     | +182        | -17           | +165       |
  | Broker module         | 10    | +2,381      | 0             | +2,381     |

  Total: 57 files, +3,306 / -151 lines

1. Broker module - Complete ZMQ broker implementation
  - New files: broker.py, communicator.py, controller.py, server.py, service.py, queue.py, protocol.py, defaults.py, utils.py

2. AiiDA CLI - New verdi broker commands + --broker option
  - New: `cmd_broker.py` (133 lines)
  - Updated: `cmd_presto.py`, `cmd_profile.py`, `setup.py`

3. Tests - New ZMQ tests + marker renames (requires_rmq → requires_broker)
  - New: `tests/brokers/test_zmq.py` (343 lines), `tests/engine/test_zmq.py` (175 lines)
  - Updated: 35 files with marker changes
  
4. CI (GitHub workflows) - Simplified to use ZMQ broker for presto profiles
  - `ci-code.yml`, `release.yml`


### Design considerations that were not taken

#### Starting broker in the daemon instead of adding an entrypoint to the CLI

Even though starting would be simplified to one command, the daemon is at the moment only responsible for worker. Breaking this to inhomogeneous processes by adding the broker causes other issues to the daemon interface (What if only the broker failed? How you only restart the broker?) that are not trivial to solve. Therefore to be consistent with the current behavior using RMQ is to me more worth rather than the ~400 lines of code.

#### No persistency and no reply pattern, vanilla ZMQ to simplify broker code

Even building a broker on top of ZMQ takes some significant amount of code (This PR ~2.4k lines of code), however only ~400 lines are really responsible for the persistence and acknowledgement pattern. While this would be a simplification, not having the features in one broker creates inconsistencies for the user and tests that create other problems. If we do do not persist the task queue, then one cannot submit anything when no worker is running. Even we make in this case submit blocking, or we do fire-and-forget. Both solutions have more subsequent problems. In general it would be acceptable that a worker is required, if the broker is responsible for the worker but that is not the design of AiiDA, so it is hard to enforce this now.